### PR TITLE
Empty filter does not work

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -298,6 +298,9 @@ function authLdap_login($foo,$username, $password, $already_md5 = false)
             // No cookie, so have to authenticate them via LDAP
             //$authLDAPURI = 'ldap:/foo:bar@server/trallala';
             $result = false;
+
+            if (empty($authLDAPFilter)) $authLDAPFilter = "(uid=%s)";
+
             try {
                 $server = new LDAP($authLDAPURI,$authLDAPDebug);
                 $result = $server->Authenticate ($username, $password, $authLDAPFilter);


### PR DESCRIPTION
If the filter was set and gets removed, authLdap tries to find entries with an empty filter. This does return unexpected results. The default parameter does only work if there never was a filter set. See http://www.php.net/manual/en/functions.arguments.php#example-142
