### PR TITLE
remove empty elements from requested attributes

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -201,7 +201,7 @@ function authLdap_login($user, $username, $password, $already_md5 = false)
         }
 
         authldap_debug('LDAP authentication successfull');
-        $attributes = array($authLDAPNameAttr, $authLDAPSecName, $authLDAPMailAttr, $authLDAPWebAttr);
+        $attributes = array_filter(array($authLDAPNameAttr, $authLDAPSecName, $authLDAPMailAttr, $authLDAPWebAttr));
         try {
             $attribs = $server->search(sprintf($authLDAPFilter, $username), $attributes);
             // First get all the relevant group informations so we can see if


### PR DESCRIPTION
Hi,

if some attributes in the config screen are left empty, the search still tries to request them.
This leads to weird requests (e.g. ```SRCH attr=givenName sn mail 1.1```, where ```1.1``` is the result of the empty elements).
This patch removes those empty elements from the requested attributes array.

EmTeedee