### PR TITLE
Adds Eyecandy to remove unneeded config-parts

### DIFF
--- a/view/admin.phtml
+++ b/view/admin.phtml
@@ -58,6 +58,17 @@
                         <input type="checkbox" name="authLDAPCachePW" id="authLDAPCachePW" value="1"<?php echo $tPWChecked; ?>/>
                     </td>
                 </tr>
+                <tr>
+                    <th>
+                        <label for="authLDAPGroupEnable">Map LDAP Groups to wordpress Roles?</label>
+                    </th>
+                    <td>
+                        <input type="checkbox" name="authLDAPGroupEnable" id="authLDAPGroupEnable" value="1"<?php echo $tGroupChecked; ?>/>
+                        <p class="description">
+                            Search LDAP for user's groups and map to Wordpress Roles.
+                        </p>
+                    </td>
+                </tr>
             </table>
         </fieldset>
         <h3 class="title">General Server Settings</h3>
@@ -221,21 +232,11 @@
         </fieldset>
 
 
+        <div id="authldaprolemapping">
         <h3 class="title">Groups for Roles</h3>
         <fieldset class="options">
             <table class="form-table">
-                <tr>
-                    <th>
-                        <label for="authLDAPGroupEnable">Use LDAP Groups to map to Roles?</label>
-                    </th>
-                    <td>
-                        <input type="checkbox" name="authLDAPGroupEnable" id="authLDAPGroupEnable" value="1"<?php echo $tGroupChecked; ?>/>
-                        <p class="description">
-                            Search LDAP for user's groups and map to Wordpress Roles.
-                        </p>
-                    </td>
-                </tr>
-                <tr>
+                 <tr>
                     <th scope="row">
                         <label for="authLDAPGroupAttr">Group-Attribute</label>
                     </th>
@@ -308,5 +309,22 @@
                 <input type="submit" name="ldapOptionsSave" class="button button-primary" value="Save Changes" />
             </p>
         </fieldset>
+        </div>
     </form>
 </div>
+
+<script type="text/javascript">
+    elem = document.getElementById('authLDAPGroupEnable');
+    if(! elem.checked) {
+        document.getElementById('authldaprolemapping').setAttribute('style', 'display:none;');
+    }
+
+    elem.addEventListener('change', function(e){
+        if(! e.target.checked) {
+            document.getElementById('authldaprolemapping').setAttribute('style', 'display:none;');
+        } else {
+            document.getElementById('authldaprolemapping').removeAttribute('style');
+        }
+    });
+
+</script>


### PR DESCRIPTION
This PR adds some javascript to remove the LDAP-Groupmapping-stuff
when no GroupMapping shall be used.

This simply hides the entries so they are not lost but simply not shown