### PR TITLE
Disabling groups is not working with second checkbox

### DIFF
--- a/view/admin.phtml
+++ b/view/admin.phtml
@@ -241,17 +241,6 @@
             <table class="form-table">
                 <tr>
                     <th>
-                        <label for="authLDAPGroupEnable">Use LDAP Groups to map to Roles?</label>
-                    </th>
-                    <td>
-                        <input type="checkbox" name="authLDAPGroupEnable" id="authLDAPGroupEnable" value="1"<?php echo $tGroupChecked; ?>/>
-                        <p class="description">
-                            Search LDAP for user's groups and map to Wordpress Roles.
-                        </p>
-                    </td>
-                </tr>
-                <tr>
-                    <th>
                         <label for="authLDAPGroupOverUser">LDAP Groups override role of existing users?</label>
                     </th>
                     <td>


### PR DESCRIPTION
Hi,

looks like the checkbox for `authLDAPGroupEnable` has creeped in twice.
The first one has the handling to hide the options for groups, so if I disable groups at the top, the options for groups (including the second checkbox to enable them) is hidden away.
But, that checkbox is still ticked and submitted, so groups remain enabled.
The only way to disable groups is to first uncheck the option at the bottom, then uncheck the same option at the top.

This fixes the issue by removing the bottom one of those checkboxes.