### PR TITLE
Force bind with dsa account or anonymous before a search operation

### DIFF
--- a/ldap.php
+++ b/ldap.php
@@ -182,6 +182,8 @@ class LDAP
 	    if ( ! is_Resource ( $this->_ch ) ) {
             throw new AuthLDAP_Exception('No resource handle avbailable' );
         }
+        // Force binding with our dsa / anonymous account
+        $this->bind();
         $result = @ldap_search ($this->_ch, $this->_baseDn, $filter, $attributes);
         if ( $result === false ){
             throw new AuthLDAP_Exception('no result found');


### PR DESCRIPTION
I force bind with dsa account / anonymous accont before a search operation because I think that the authenticate operation assign the user bind.

if ( $username && $password ){
  if ( @ldap_bind($this->_ch, $dn, $password) ){
    return true;
  }
}