### PR TITLE
Use proper WP prefix when looking up user roles

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -428,7 +428,7 @@ function authLdap_user_role($uid)
         return '';
     }
 
-    $meta_value = $wpdb->get_var("SELECT meta_value FROM {$wpdb->usermeta} WHERE meta_key = 'wp_capabilities' AND user_id = {$uid}");
+    $meta_value = $wpdb->get_var("SELECT meta_value FROM {$wpdb->usermeta} WHERE meta_key = '{$wpdb->prefix}capabilities' AND user_id = {$uid}");
 
     if (!$meta_value) {
         return '';


### PR DESCRIPTION
Changed the lookup of meta_key = wp_capabilities within the authLdap_user_role to take custom prefixes into account instead of assuming 'wp_' prefix. Fixes #69