### PR TITLE
Removes the password-changed Email to the user

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -748,15 +748,15 @@ function authLdap_set_options($new_options = array())
 }
 
 /**
- * Do not send an email after changing the password of the user!
+ * Do not send an email after changing the password or the email of the user!
  *
- * @param $result
- * @param $user
- * @param $newUserData
+ * @param boolean $result      The initial resturn value
+ * @param array   $user        The old userdata
+ * @param array   $newUserData The changed userdata
  *
  * @return bool
  */
-function authLdap_send_password_change_email($result, $user, $newUserData)
+function authLdap_send_change_email($result, $user, $newUserData)
 {
     if (get_usermeta($user['ID'], 'authLDAP')) {
         return false;
@@ -769,4 +769,5 @@ add_action('admin_menu', 'authLdap_addmenu');
 add_filter('show_password_fields', 'authLdap_show_password_fields');
 add_filter('authenticate', 'authLdap_login', 10, 3);
 /** This only works from WP 4.3.0 on */
-add_filter('send_password_change_email', 'authLdap_send_password_change_email', 10, 3);
+add_filter('send_password_change_email', 'authLdap_send_change_email', 10, 3);
+add_filter('send_email_change_email', 'authLdap_send_change_email', 10, 3);

--- a/authLdap.php
+++ b/authLdap.php
@@ -747,6 +747,26 @@ function authLdap_set_options($new_options = array())
     }
 }
 
+/**
+ * Do not send an email after changing the password of the user!
+ *
+ * @param $result
+ * @param $user
+ * @param $newUserData
+ *
+ * @return bool
+ */
+function authLdap_send_password_change_email($result, $user, $newUserData)
+{
+    if (get_usermeta($user['ID'], 'authLDAP')) {
+        return false;
+    }
+
+    return $result;
+}
+
 add_action('admin_menu', 'authLdap_addmenu');
 add_filter('show_password_fields', 'authLdap_show_password_fields');
 add_filter('authenticate', 'authLdap_login', 10, 3);
+/** This only works from WP 4.3.0 on */
+add_filter('send_password_change_email', 'authLdap_send_password_change_email', 10, 3);


### PR DESCRIPTION
This email has been anoying for users that changed their password in the
LDAP and then logged into wordpress as wordpress noticed the change and
sent an email hat the password has been changed.

This will not happen with WP 4.3.0 anymore.

This has been reported by
[litinoveweedle](https://github.com/litinoveweedle) in issue #80