### PR TITLE
fix php parse error on ubuntu 14.04/php 5.3.10

### DIFF
--- a/src/LdapList.php
+++ b/src/LdapList.php
@@ -31,7 +31,7 @@ class LdapList
     /**
      * @var \LDAP[]
      */
-    protected $items = [];
+    protected $items = array();
 
     public function addLdap(LDAP $ldap)
     {


### PR DESCRIPTION
This seems to be the modern php way to initialize an array and it fixed a wordpress site that was unable to login (probably since the introduction of this code, but perhaps it wasn't used since july 2016).