### PR TITLE
Adds WPMU-support for login

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -20,8 +20,10 @@ function authLdap_debug($message)
 
 function authLdap_addmenu()
 {
-    if (function_exists('add_options_page')) {
+    if (! is_multisite()) {
         add_options_page('AuthLDAP', 'AuthLDAP', 'manage_options', basename(__FILE__), 'authLdap_options_panel');
+    } else {
+        add_submenu_page('settings.php', 'AuthLDAP', 'AuthLDAP', 'manage_options', 'authldap', 'authLdap_options_panel');
     }
 }
 
@@ -652,8 +654,12 @@ function authLdap_load_options($reload = false)
     // the current version for options
     $option_version_plugin = 1;
 
+    $optionFunction = 'get_option';
+    if (is_multisite()) {
+        $optionFunction = 'get_site_option';
+    }
     if (is_null($options) || $reload) {
-        $options = get_option('authLDAPOptions', array());
+        $options = $optionFunction('authLDAPOptions', array());
     }
 
     // check if option version has changed (or if it's there at all)
@@ -759,15 +765,19 @@ function authLdap_set_options($new_options = array())
     }
 
     // store options
-    if (update_option('authLDAPOptions', $options)) {
+    $optionFunction = 'update_option';
+    if (is_multisite()) {
+        $optionFunction = 'update_site_option';
+    }
+    if ($optionFunction('authLDAPOptions', $options)) {
         // reload the option cache
         authLdap_load_options(true);
 
         return true;
-    } else {
-        // could not set options
-        return false;
     }
+
+    // could not set options
+    return false;
 }
 
 /**
@@ -788,7 +798,8 @@ function authLdap_send_change_email($result, $user, $newUserData)
     return $result;
 }
 
-add_action('admin_menu', 'authLdap_addmenu');
+$hook = is_multisite() ? 'network_' : '';
+add_action('admin_menu', $hook . 'authLdap_addmenu');
 add_filter('show_password_fields', 'authLdap_show_password_fields', 10, 2);
 add_filter('allow_password_reset', 'authLdap_allow_password_reset', 10, 2);
 add_filter('authenticate', 'authLdap_login', 10, 3);

--- a/authLdap.php
+++ b/authLdap.php
@@ -799,7 +799,7 @@ function authLdap_send_change_email($result, $user, $newUserData)
 }
 
 $hook = is_multisite() ? 'network_' : '';
-add_action('admin_menu', $hook . 'authLdap_addmenu');
+add_action($hook . 'admin_menu', 'authLdap_addmenu');
 add_filter('show_password_fields', 'authLdap_show_password_fields', 10, 2);
 add_filter('allow_password_reset', 'authLdap_allow_password_reset', 10, 2);
 add_filter('authenticate', 'authLdap_login', 10, 3);

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: heiglandreas
 Tags: ldap, auth
 Requires at least: 2.5.0
-Tested up to: 4.7.4
+Tested up to: 4.9.0
 Stable tag: trunk
 
 Use your existing LDAP flexible as authentication backend for WordPress
@@ -41,6 +41,11 @@ Go to https://github.com/heiglandreas/authLdap
 Please use the issuetracker at https://github.com/heiglandreas/authLdap/issues
 
 == Changelog ==
+= 2.0.0 =
+* This new release adds Multi-Site support. It will no longer be possible to use this plugin just in one subsite of a multisite installation!
+* Adds a warning screen to the config-section when no LDAPextension could be found
+* Fixes an issue with the max-length of the username
+
 = 1.5.1 =
 * Fixes an issue with escaped backslashes and quotes
 


### PR DESCRIPTION
This PR adds support for using the plugin as authentication-backend for a MultiSite-environment.

It will no longer be possible to be used only for one site within a MultiSite-setup!

As this is a BC-break it will need to be included in a Major-version.