### PR TITLE
Change Role-group mapping to use textarea.

### DIFF
--- a/view/admin.phtml
+++ b/view/admin.phtml
@@ -200,7 +200,7 @@
                         </p>
                         <p class="description">
                             This field defaults to <strong>uid</strong>
-cd                         </p>
+                        </p>
                     </td>
                 </tr>
                 <tr>

--- a/view/admin.phtml
+++ b/view/admin.phtml
@@ -200,7 +200,7 @@
                         </p>
                         <p class="description">
                             This field defaults to <strong>uid</strong>
-                        </p>
+cd                         </p>
                     </td>
                 </tr>
                 <tr>
@@ -355,8 +355,7 @@
                         </label>
                     </th>
                     <td>
-                        <input type="text" name="authLDAPGroups[<?php echo $group; ?>]" id="authLDAPGroups[<?php echo $group; ?>]"
-                          value="<?php echo $aGroup; ?>" />
+			<textarea name="authLDAPGroups[<?php echo $group; ?>]" id="authLDAPGroups[<?php echo $group; ?>]" cols=60 rows=5><?php echo $aGroup; ?></textarea>
                         <p class="description">What LDAP-Groups shall be matched to the <?php echo $vals; ?>-Role?</p>
                         <p class="description">Please provide a coma-separated list of values</p>
                         <p class="description">This field is empty by default</p>


### PR DESCRIPTION
Small UI tweak which makes it easier to see that more than one group can be specified for a role mapping. Especially useful if groups are identified by longer strings.