### PR TITLE
BugFix: Allow multiple usage of %s for username substitution

### DIFF
--- a/ldap.php
+++ b/ldap.php
@@ -240,7 +240,7 @@ class LDAP
         //return true;
         $this->connect();
         $this->bind();
-        $res = $this->search(sprintf($filter, $username));
+        $res = $this->search(str_replace('%s', $username, $filter));
         if (! $res || ! is_array($res) || ( $res ['count'] != 1 )) {
             return false;
         }


### PR DESCRIPTION
Currently the sprintf() will complain about too few arguments when multiple "%s" are used in the User login "Filter".
This happens when drafting a filter which would match upon uid AND mail - so that users could login via uid OR mail: `(|(uid=%s)(mail=%s))`. The solution is to use str_replace() to substitute all occurences.