### PR TITLE
allow to specify different base DN for group lookups

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -53,6 +53,7 @@ function authLdap_options_panel()
             'Groups'        => authLdap_get_post('authLDAPGroups', array()),
             'GroupSeparator'=> authLdap_get_post('authLDAPGroupSeparator', ','),
             'Debug'         => authLdap_get_post('authLDAPDebug', false),
+            'GroupBase'     => authLdap_get_post('authLDAPGroupBase'),
             'GroupAttr'     => authLdap_get_post('authLDAPGroupAttr'),
             'GroupFilter'   => authLdap_get_post('authLDAPGroupFilter'),
             'DefaultRole'   => authLdap_get_post('authLDAPDefaultRole'),
@@ -81,6 +82,7 @@ function authLdap_options_panel()
     $authLDAPGroups        = authLdap_get_option('Groups');
     $authLDAPGroupSeparator= authLdap_get_option('GroupSeparator');
     $authLDAPDebug         = authLdap_get_option('Debug');
+    $authLDAPGroupBase     = authLdap_get_option('GroupBase');
     $authLDAPGroupAttr     = authLdap_get_option('GroupAttr');
     $authLDAPGroupFilter   = authLdap_get_option('GroupFilter');
     $authLDAPDefaultRole   = authLdap_get_option('DefaultRole');
@@ -477,6 +479,7 @@ function authLdap_user_role($uid)
  * @param string $dn
  * @return string role, empty string if no mapping found, first found role otherwise
  * @conf array authLDAPGroups, associative array, role => ldap_group
+ * @conf string authLDAPGroupBase, base dn to look up groups
  * @conf string authLDAPGroupAttr, ldap attribute that holds name of group
  * @conf string authLDAPGroupFilter, LDAP filter to find groups. can contain %s and %dn% placeholders
  */
@@ -485,6 +488,7 @@ function authLdap_groupmap($username, $dn)
     $authLDAPGroups         = authLdap_sort_roles_by_capabilities(
         authLdap_get_option('Groups')
     );
+    $authLDAPGroupBase      = authLdap_get_option('GroupBase');
     $authLDAPGroupAttr      = authLdap_get_option('GroupAttr');
     $authLDAPGroupFilter    = authLdap_get_option('GroupFilter');
     $authLDAPGroupSeparator = authLdap_get_option('GroupSeparator');
@@ -508,7 +512,8 @@ function authLdap_groupmap($username, $dn)
         // string %dn% with the users DN.
         $authLDAPGroupFilter = str_replace('%dn%', $dn, $authLDAPGroupFilter);
         authLdap_debug('Group Filter: ' . json_encode($authLDAPGroupFilter));
-        $groups = authLdap_get_server()->search(sprintf($authLDAPGroupFilter, $username), array($authLDAPGroupAttr));
+        authLdap_debug('Group Base: ' . $authLDAPGroupBase);
+        $groups = authLdap_get_server()->search(sprintf($authLDAPGroupFilter, $username), array($authLDAPGroupAttr), $authLDAPGroupBase);
     } catch (Exception $e) {
         authLdap_debug('Exception getting LDAP group attributes: ' . $e->getMessage());
         return '';

--- a/ldap.php
+++ b/ldap.php
@@ -188,14 +188,18 @@ class LDAP
      *
      * @param string $filter
      * @param array $attributes
+     * @param string $base
      * @return array
      */
-    public function search($filter, $attributes = array('uid'))
+    public function search($filter, $attributes = array('uid'), $base = '' )
     {
         if (! is_Resource($this->_ch)) {
             throw new AuthLDAP_Exception('No resource handle avbailable');
         }
-        $result = @ldap_search($this->_ch, $this->_baseDn, $filter, $attributes);
+        if (! $base) {
+          $base = $this->_baseDn;
+        }
+        $result = ldap_search($this->_ch, $base, $filter, $attributes);
         if ($result === false) {
             throw new AuthLDAP_Exception('no result found');
         }

--- a/src/LdapList.php
+++ b/src/LdapList.php
@@ -71,11 +71,11 @@ class LdapList
         return true;
     }
 
-    public function search($filter, $attributes = array('uid'))
+    public function search($filter, $attributes = array('uid'), $base = '')
     {
         foreach ($this->items as $item) {
             try {
-                $result = $item->search($filter, $attributes);
+                $result = $item->search($filter, $attributes, $base);
                 return $result;
             } catch (Exception $e) {
                 throw $e;

--- a/view/admin.phtml
+++ b/view/admin.phtml
@@ -282,6 +282,21 @@
                 </tr>
                 <tr>
                     <th scope="row">
+                        <label for="authLDAPGroupBase">Group-Base</label>
+                    </th>
+                    <td>
+                        <input type="text" name="authLDAPGroupBase" id="authLDAPGroupBase" placeholder=""
+                          class="regular-text" value="<?php echo $authLDAPGroupBase; ?>" />
+                        <p class="description">
+                            This is the base dn to lookup groups.
+                        </p>
+                        <p class="description">
+                            If empty the base dn of the LDAP URI will be used
+                        </p>
+                    </td>
+                </tr>
+                <tr>
+                    <th scope="row">
                         <label for="authLDAPGroupAttr">Group-Attribute</label>
                     </th>
                     <td>


### PR DESCRIPTION
I have multiple wordpresses, which use a single ldap base.
Users have different rights in different WP installations.
I have a ou for each WP with user groups in those.
so i need to set the group-search base-dn for each WP installation to be different from the user-dn.

This patch adds a option to specify the search base in the ldap->search function. if none is specified, the search base is taken from the ldap-uri (same as before this patch).

_This is a redo of #163 using a feature branch (im sort of new to this branch thing)_