### PR TITLE
Authnetification through username and email

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -6,6 +6,8 @@ Description: This plugin allows you to use your existing LDAP as authentication 
 Version: 2.1.0
 Author: Andreas Heigl <a.heigl@wdv.de>
 Author URI: http://andreas.heigl.org
+License: MIT
+License URI: https://opensource.org/licenses/MIT
 */
 
 require_once dirname(__FILE__) . '/ldap.php';

--- a/authLdap.php
+++ b/authLdap.php
@@ -6,8 +6,6 @@ Description: This plugin allows you to use your existing LDAP as authentication 
 Version: 2.1.0
 Author: Andreas Heigl <a.heigl@wdv.de>
 Author URI: http://andreas.heigl.org
-License: MIT
-License URI: https://opensource.org/licenses/MIT
 */
 
 require_once dirname(__FILE__) . '/ldap.php';
@@ -276,7 +274,7 @@ function authLdap_login($user, $username, $password, $already_md5 = false)
 
         try {
             $attribs = authLdap_get_server()->search(
-                sprintf($authLDAPFilter, $username),
+                join($username, explode("%s",$authLDAPFilter)),
                 $attributes
             );
             // First get all the relevant group informations so we can see if

--- a/ldap.php
+++ b/ldap.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * $Id: ldap.php 381646 2011-05-06 09:37:31Z heiglandreas $
+ * $Id: ldap.php 2045782 2019-03-07 08:30:08Z heiglandreas $
  *
  * authLdap - Authenticate Wordpress against an LDAP-Backend.
  * Copyright (c) 2008 Andreas Heigl<andreas@heigl.org>
@@ -244,7 +244,7 @@ class LDAP
         //return true;
         $this->connect();
         $this->bind();
-        $res = $this->search(sprintf($filter, $username));
+        $res = $this->search(join($username, explode("%s",$filter)));
         if (! $res || ! is_array($res) || ( $res ['count'] != 1 )) {
             return false;
         }


### PR DESCRIPTION
I've not being able to configure the plugin to authenticate through username and email. Apparently, filter option has to have at least the condition below (I took this info from [here](https://andreas.heigl.org/2010/08/22/authldap/)), but the 'sprintf' instruction can not replace more than one format specifier per parameter. 

`(&(<some condition>)((!(uid=%s)(mail=%s)))`

Here you have the modifications that I've made to make it works.