### PR TITLE
Allow to pass a different port in URI

### DIFF
--- a/ldap.php
+++ b/ldap.php
@@ -115,7 +115,15 @@ class LDAP
             $this->port = 636;
         }
 
-        $this->ch = @ldap_connect($this->scheme . '://' . $this->server . ':' . $this -> port);
+        // Allow to pass port in server URL.
+        if (strpos($this->server, ':') !== false) {
+            $server = $this->server;
+        } else {
+            $server = $this->server . ':' . $this->port;
+        }
+
+        $this->ch = @ldap_connect($this->scheme . '://' . $server);
+
         if (! $this->ch) {
             throw new Error('Could not connect to the server');
         }

--- a/view/admin.phtml
+++ b/view/admin.phtml
@@ -104,8 +104,8 @@
                         <p class="description">
                             The <abbr title="Uniform Ressource Identifier">URI</abbr>
                             for connecting to the LDAP-Server. This usualy takes the form
-                            <var>&lt;scheme&gt;://&lt;user&gt;:&lt;password&gt;@&lt;server&gt;/&lt;path&gt;</var>
-                            according to RFC 1738.</p>
+                            <var>&lt;scheme&gt;://&lt;user&gt;:&lt;password&gt;@&lt;server:port&gt;/&lt;path&gt;</var>
+                            according to RFC 1738, where the port is optional.</p>
                         <p class="description">
                             In this case it schould be something like
                             <var>ldap://uid=adminuser,dc=example,c=com:secret@ldap.example.com/dc=basePath,dc=example,c=com</var>.


### PR DESCRIPTION
With this tiny fix once could pass the port in URL (as standard when connecting to LDAP). If not set, the defaults will be used. It's a non-breaking change.