### PR TITLE
Getter for the connection handler

### DIFF
--- a/ldap.php
+++ b/ldap.php
@@ -270,4 +270,14 @@ class LDAP
             );
         }
     }
+
+    /**
+     * Return Connection handler for custom LDAP implementations.
+     * @return Org_Heigl\AuthLdap\Ressource
+     */
+    public function getConnectionHandler()
+    {
+        return $this->ch;
+    }
+
 }


### PR DESCRIPTION
We needed to extend the authLdap plugin with few custom requests to LDAP (`ldap_modify()` etc.) and it's not possible to reuse the class you've written since the `$this->ch` is protected (so even extending class is not possible).

I've added a getter for the connection handler. What do you think, is that possible to keep in the plugin? (I'm going to push a few more extensions - I'm happy to help a bit and don't be stressed about maintaining a custom fork.

Thanks in advance!
Karolina