### PR TITLE
Fix: send success action after is_wp_error() check

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -440,6 +440,13 @@ function authLdap_login($user, $username, $password, $already_md5 = false)
             $userid = wp_insert_user($user_info);
         }
 
+        // if the user exists, wp_insert_user will update the existing user record
+        if (is_wp_error($userid)) {
+            authLdap_debug('Error creating user : ' . $userid->get_error_message());
+            trigger_error('Error creating user: ' . $userid->get_error_message());
+            return $userid;
+        }
+
         /**
          * Add hook for custom updates
          *
@@ -447,13 +454,6 @@ function authLdap_login($user, $username, $password, $already_md5 = false)
          * @param array $attribs[0] Attributes retrieved from LDAP for the user.
          */
         do_action('authLdap_login_successful', $userid, $attribs[0]);
-
-        // if the user exists, wp_insert_user will update the existing user record
-        if (is_wp_error($userid)) {
-            authLdap_debug('Error creating user : ' . $userid->get_error_message());
-            trigger_error('Error creating user: ' . $userid->get_error_message());
-            return $userid;
-        }
 
         authLdap_debug('user id = ' . $userid);
 


### PR DESCRIPTION
Call custom add_action hook after `is_wp_error()` check so the action always get's user ID (int) not `WP_Error`. 

Sorry for the mess, it was my mistake and it took me more than half a year to find it out.