### PR TITLE
Allow login with username OR mail

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -311,7 +311,7 @@ function authLdap_login($user, $username, $password, $already_md5 = false)
 
         try {
             $attribs = authLdap_get_server()->search(
-                sprintf($authLDAPFilter, $username),
+                str_replace("%s", $username, $authLDAPFilter),
                 $attributes
             );
             // First get all the relevant group informations so we can see if

--- a/ldap.php
+++ b/ldap.php
@@ -246,7 +246,7 @@ class LDAP
         //return true;
         $this->connect();
         $this->bind();
-        $res = $this->search(sprintf($filter, ldap_escape($username, '', LDAP_ESCAPE_FILTER)));
+        $res = $this->search(str_replace("%s", ldap_escape($username, '', LDAP_ESCAPE_FILTER), $filter));
         if (! $res || ! is_array($res) || ( $res ['count'] != 1 )) {
             return false;
         }


### PR DESCRIPTION
I want to allow users to login using their username or their email.
I set the filter `(|(uid=%s)(mail=%s))`, but i have the error:

> PHP Warning:  sprintf(): Too few arguments in /var/www/wordpress/wp-content/plugins/authldap/ldap.php on line 249

Use `str_replace` instead of `sprintf` fix the issue. But I'm not a php dev, there is probably a more elegant way to do it.