### PR TITLE
Find first role in capabilities

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -505,23 +505,21 @@ function authLdap_get_uid($username)
  */
 function authLdap_user_role($uid)
 {
-    global $wpdb;
+    global $wpdb, $wp_roles;
 
     if (!$uid) {
         return '';
     }
 
-    $meta_value = $wpdb->get_var(
-        "SELECT meta_value FROM {$wpdb->usermeta} WHERE meta_key = '{$wpdb->prefix}capabilities' AND user_id = {$uid}"
-    );
-
-    if (!$meta_value) {
+    $usercapabilities = get_user_meta( $uid, "{$wpdb->prefix}capabilities", true);
+    if ( ! is_array( $usercapabilities ) ) {
         return '';
     }
+    
+    $editable_roles = apply_filters('editable_roles', $wp_roles->roles);
 
-    $capabilities = unserialize($meta_value);
-    $roles = is_array($capabilities) ? array_keys($capabilities) : array('');
-    $role = $roles[0];
+    $userroles = array_keys( array_intersect_key($editable_roles, $usercapabilities) );
+    $role = &$userroles[0];
 
     authLdap_debug("Existing user's role: {$role}");
     return $role;

--- a/authLdap.php
+++ b/authLdap.php
@@ -519,7 +519,7 @@ function authLdap_user_role($uid)
     $editable_roles = apply_filters('editable_roles', $wp_roles->roles);
 
     $userroles = array_keys( array_intersect_key($editable_roles, $usercapabilities) );
-    $role = &$userroles[0];
+    $role = $userroles[0];
 
     authLdap_debug("Existing user's role: {$role}");
     return $role;


### PR DESCRIPTION
This is a fix to an issue which obviously popped up in the forum earlier by the thread [Seeing permissions as Role by Barry Sampson](https://wordpress.org/support/topic/seeing-permission-as-role/).

The problem: The usermeta {$wpdb->prefix}capabilities contains more than just the role. Even worse, the role may not be the first entry, which is expected in the previous version.

Since it stroke us too, we fixed it. The fix only applies to a single function.

Kind regards.