### PR TITLE
Allow querying with the user's credentials

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -286,7 +286,7 @@ function authLdap_login($user, $username, $password, $already_md5 = false)
         }
 	
 		// Make optional querying from the admin account #213
-        if (authLdap_get_option('UserRead')) {
+        if (! authLdap_get_option('UserRead')) {
 			// Rebind with the default credentials after the user has been loged in
 			// Otherwise the credentials of the user trying to login will be used
 			// This fixes #55

--- a/view/admin.phtml
+++ b/view/admin.phtml
@@ -186,6 +186,18 @@
             <table class="form-table">
                 <tr>
                     <th scope="row">
+                        <label for="authLDAPUseUserAccount">User-Read</label>
+                    </th>
+                    <td>
+                        <input type="checkbox" name="authLDAPUseUserAccount" id="authLDAPUseUserAccount" value="1"<?php echo $tUserRead; ?>/><br />
+                        <p class="description">
+                            If checked the plugin will use the user's account to query their own information. If not it will use the admin account.
+                        </p>
+						
+                    </td>
+                </tr>
+				<tr>
+                    <th scope="row">
                         <label for="authLDAPNameAttr">Name-Attribute</label>
                     </th>
                     <td>


### PR DESCRIPTION
Closes #213 

It introduces a new option (the default leaves things working as they were) to use the user account to feach the different atributes of the user. Before the admin account was the one responsible for fetching those attributes.

WIP: Maybe change the name of the option, but I doesn't come one fit to mind.