### PR TITLE
Do not add empty string to `roles` array

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -367,7 +367,11 @@ function authLdap_login($user, $username, $password, $already_md5 = false)
 		// we only need this if either LDAP groups are disabled or
 		// if the WordPress role of the user overrides LDAP groups
 		if (!$authLDAPGroupEnable || !$authLDAPGroupOverUser) {
-			$roles[] = authLdap_user_role($uid);
+			$role = authLdap_user_role($uid);
+
+			if ($role) {
+				$roles[] = $role;
+			}
 			// TODO, this needs to be revised, it seems, like authldap is taking only the first role
 			// even if in WP there are assigned multiple.
 		}


### PR DESCRIPTION
I noticed that the default role option seems to have no effect when a new user is created via authLdap and the LDAP group options are completely disabled.

I investigated the problem in my installation and found that `authLdap_user_role($uid)` returns an empty string for the user that doesn't yet exist, and so the empty string is appended to the `$roles` array. This in turn causes all subsequent `empty($roles)` checks to evaluate to `false` and accordingly the default role option can never take effect. So the user ends up with no role instead of an actual role.

WordPress version: 6.2.2
PHP version: 8.2

I've verified this fix in my installation. If you want to take a different approach, feel free to do so. For now, I've implemented this (temporary) solution, but it would be great if there was a fix in the next version so that my manual changes don't get overwritten and the same problem starts occuring again :-)