### PR TITLE
Divide between authentication and authorization

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -24,12 +24,12 @@ jobs:
         uses: ScribeMD/docker-cache@0.5.0
         with:
           key:
-            docker-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.wordpress-version }}-${{ hashFiles('docker-compose.yml') }}
-      - name: Build the docker-compose stack
+            docker-${{ runner.os }}-${{ matrix.php-version }}-${{ matrix.wordpress-version }}-${{ hashFiles('compose.yml') }}
+      - name: Build the docker compose stack
         if: steps.docker-cache.outputs.cache-hit != 'true'
         run: docker compose build --build-arg PHP_VERSION=${{ matrix.php-version }} --build-arg WORDPRESS_VERSION=${{ matrix.wordpress-version }} wp
       - name: run the stack
-        run: docker compose -f docker-compose.yml up -d
+        run: docker compose -f compose.yml up -d
       - name: Check running containers
         run: docker ps -a
       - name: Check logs

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -16,7 +16,7 @@ jobs:
 
     name: Test on PHP ${{ matrix.php-version }}/WordPress ${{ matrix.wordpress-version }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
 #      - name: Docker Compose Pull
 #        run: docker compose pull
       - name: Cache Docker images

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -11,8 +11,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4-rc']
-        wordpress-version: ['6.2', '6.3', '6.4', '6.5', '6.6']
+        php-version: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        wordpress-version: ['6.2', '6.3', '6.4', '6.5', '6.6', '6.7']
 
     name: Test on PHP ${{ matrix.php-version }}/WordPress ${{ matrix.wordpress-version }}
     steps:

--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -1,5 +1,10 @@
 name: Behat Tests
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/codacy.yml
+++ b/.github/workflows/codacy.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
       # Checkout the repository to the GitHub Actions runner
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # Execute Codacy Analysis CLI and generate a SARIF output with the security issues identified during the analysis
       - name: Run Codacy Analysis CLI

--- a/.github/workflows/deploy_on_release.yml
+++ b/.github/workflows/deploy_on_release.yml
@@ -12,7 +12,7 @@ jobs:
     environment: deploy_on_release
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: WordPress Plugin Deploy
         id: deploy
         uses: 10up/action-wordpress-plugin-deploy@stable
@@ -22,11 +22,11 @@ jobs:
           SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
       - name: Upload release asset
-        uses: actions/upload-release-asset@v1
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ github.event.release.upload_url }}
+          files: ${{ github.event.release.upload_url }}
           asset_path: ${{ steps.deploy.outputs.zip-path }}
           asset_name: ${{ env.SLUG }}.zip
           asset_content_type: application/zip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,7 +46,7 @@ jobs:
     continue-on-error: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Build the docker-compose stack
         run: docker compose -f docker-compose.yml up -d
       - name: Check running containers

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - 'master'
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,11 @@ jobs:
         php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
     name: Test on ${{ matrix.php-versions }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - uses: jpribyl/action-docker-layer-caching@v0.1.1
         continue-on-error: true
-      - name: Build the docker-compose stack
-        run: docker compose -f docker-compose.yml up -d db openldap
+      - name: Build the docker compose stack
+        run: docker compose -f compose.yml up -d db openldap
       - name: Check running containers
         run: docker ps -a
       - name: Check logs
@@ -28,7 +28,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-versions }}
           extensions: ldap
-          tools: phive
       - name: install dependencies
         run: composer install
       - name: install tools
@@ -47,8 +46,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Build the docker-compose stack
-        run: docker compose -f docker-compose.yml up -d
+      - name: Build the docker compose stack
+        run: docker compose -f compose.yml up -d
       - name: Check running containers
         run: docker ps -a
       - name: Setup PHP

--- a/compose.yml
+++ b/compose.yml
@@ -1,12 +1,12 @@
 services:
   wp:
-    image: authldap_test:${WORDPRESS_VERSION:-6.6}-${PHP_VERSION:-8.4-rc}
+    image: authldap_test:${WORDPRESS_VERSION:-6.7}-${PHP_VERSION:-8.4}
     build:
       context: dockersetup
       dockerfile: Dockerfile_wordpress
       args:
-        PHP_VERSION: ${PHP_VERSION:-8.3}
-        WORDPRESS_VERSION: ${WORDPRESS_VERSION:-6.6}
+        PHP_VERSION: ${PHP_VERSION:-8.4}
+        WORDPRESS_VERSION: ${WORDPRESS_VERSION:-6.7}
     volumes:
       - .:/var/www/html/wp-content/plugins/authldap
       - wordpress:/var/www/html

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       WORDPRESS_DB_NAME: "wordpress"
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: "wppasswd"
-      WORDPRESS_DEBUG: 0
+      WORDPRESS_DEBUG: 1
     depends_on:
       db:
         condition: service_healthy
@@ -30,8 +30,8 @@ services:
       - ./dockersetup/nginx/default.conf:/etc/nginx/conf.d/default.conf
       - .:/var/www/html/wp-content/plugins/authldap
       - wordpress:/var/www/html
-    ports:
-      - 80:80
+    #ports:
+    #  - 80:80
     links:
       - wp:wp
     depends_on:
@@ -54,8 +54,8 @@ services:
 
   db:
     image: mysql:latest # https://hub.docker.com/_/mysql/ - or mariadb https://hub.docker.com/_/mariadb
-    ports:
-      - 3306:3306 # change ip if required
+    #ports:
+    #  - 3306:3306 # change ip if required
     command: [
       '--character-set-server=utf8mb4',
       '--collation-server=utf8mb4_unicode_ci'

--- a/dockersetup/Dockerfile_wordpress
+++ b/dockersetup/Dockerfile_wordpress
@@ -27,6 +27,7 @@ RUN set -x \
     && curl -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \
     && chmod 755 /usr/local/bin/wp \
     && /usr/local/bin/wp --allow-root core download --version $WORDPRESS_VERSION \
+    && /usr/local/bin/wp --allow-root cli update --nightly --yes
 
 
 

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -30,7 +30,6 @@ class FeatureContext implements Context
 	 */
 	public static function beforeSuite()
 	{
-		exec('wp --allow-root cli update --nightly');
 		exec('wp --allow-root config create --dbname=wordpress --dbuser=root --dbpass=wppasswd --dbhost=db');
 		exec('wp --allow-root core install --url=localhost --title=Example --admin_user=localadmin --admin_password=P@ssw0rd --admin_email=info@example.com');
 		exec('wp --allow-root plugin is-active authldap', $response, $code);

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -30,6 +30,7 @@ class FeatureContext implements Context
 	 */
 	public static function beforeSuite()
 	{
+		exec('wp --allow-root cli update --nightly');
 		exec('wp --allow-root config create --dbname=wordpress --dbuser=root --dbpass=wppasswd --dbhost=db');
 		exec('wp --allow-root core install --url=localhost --title=Example --admin_user=localadmin --admin_password=P@ssw0rd --admin_email=info@example.com');
 		exec('wp --allow-root plugin is-active authldap', $response, $code);

--- a/features/log in using no groups at all.feature
+++ b/features/log in using no groups at all.feature
@@ -48,11 +48,9 @@ Feature: Log in without group assignment
 		And an LDAP user "ldapuser" with name "LDAP User", password "P@ssw0rd" and email "ldapuser@example.com" exists
 		And an LDAP group "ldapgroup" exists
 		And LDAP user "ldapuser" is member of LDAP group "ldapgroup"
-		And a WordPress user "wordpressuser" with name "WordPress_User" and email "wordpressuser@example.com" exists
-		And a WordPress role "wordpressrole" exists
-		And WordPress user "wordpressuser" has role "wordpressrole"
 		And a WordPress user "ldapuser" does not exist
 		And user "ldapuser" logs in with password "P@ssw0rd"
+		And the WordPress user "ldapuser" is not member of role "subscriber"
 		And WordPress user "ldapuser" has role "wordpressrole"
 		And the WordPress user "ldapuser" is member of role "wordpressrole"
 		When user "ldapuser" logs in with password "P@ssw0rd"

--- a/src/Authenticate.php
+++ b/src/Authenticate.php
@@ -1,0 +1,86 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap;
+
+use Exception;
+use Org_Heigl\AuthLdap\Value\LoggedInUser;
+use Org_Heigl\AuthLdap\Value\Password;
+use Org_Heigl\AuthLdap\Value\UserFilter;
+use Org_Heigl\AuthLdap\Value\Username;
+use WP_Error;
+use WP_User;
+
+final class Authenticate
+{
+	private UserFilter $filter;
+
+	private LdapList $backend;
+	private LoggerInterface $logger;
+	public function __construct(UserFilter $filter, LdapList $backend, LoggerInterface $logger)
+	{
+		$this->filter = $filter;
+		$this->backend = $backend;
+		$this->logger = $logger;
+	}
+
+	/**
+	 * @param null|WP_User|WP_Error
+	 * @param string $username
+	 * @param string $password
+	 * @return WP_User|WP_Error|LoggedInUser|false
+	 */
+	public function __invoke($user, $username, #[\SensitiveParameter] $password)
+	{
+		// If the user has already been authenticated (only in that case we get a
+		// WP_User-Object as $user) we skip LDAP-authentication and simply return
+		// the existing user-object
+		if ($user instanceof WP_User) {
+			$this->logger->log(sprintf(
+				'User %s has already been authenticated - skipping LDAP-Authentication',
+				$user->get('nickname')
+			));
+			return $user;
+		}
+
+		$this->logger->log(sprintf(
+			'User "%s" logging in',
+			$username
+		));
+
+		try {
+			$username = Username::fromMixed($username);
+		} catch (\InvalidArgumentException $e) {
+			$this->logger->log($e->getMessage());
+
+			return false;
+		}
+
+		try {
+			$password = Password::fromMixed($password);
+		} catch (\InvalidArgumentException $e) {
+			$this->logger->log($e->getMessage());
+			return false;
+		}
+
+		try {
+			$this->logger->log('about to do LDAP authentication');
+			if ($this->backend->Authenticate(
+				(string) $username,
+				(string) $password,
+				(string) $this->filter
+			)) {
+				$this->logger->log('LDAP authentication successful');
+				return LoggedInUser::fromUsernameAndPassword($username, $password);
+			}
+		} catch (Exception $e) {
+			$this->logger->log(sprintf(
+				'LDAP authentication failed with exception: %s',
+				$e->getMessage()
+			));
+			return false;
+		}
+
+		$this->logger->log('LDAP authentication failed');
+		return false;
+	}
+}

--- a/src/Authorize.php
+++ b/src/Authorize.php
@@ -71,10 +71,9 @@ final class Authorize
 	}
 
 	/**
-	 * @param WP_User $user
-	 * @return false|\WP_Error|WP_User
+	 * @return false|WP_User
 	 */
-	public function __invoke(\WP_User $user)
+	public function __invoke(WP_User $user)
 	{
 		try {
 			$roles = [];
@@ -91,7 +90,7 @@ final class Authorize
 			}
 
 			// do LDAP group mapping if needed
-			// (if LDAP groups override wordpress user role, $role is still empty)
+			// (if LDAP groups override WordPress user role, $role is still empty)
 			if (($roles === [] || $this->groupOverUser->isEnabled() === true) && $this->groupEnabled->isEnabled() === true) {
 				// FIXME: add correct parameters
 				$userInfoLdap = $this->backend->search(sprintf(
@@ -124,7 +123,7 @@ final class Authorize
 			$wp_roles = new WP_Roles();
 			// not sure if this is needed, but it can't hurt
 
-			// Get rid of unexisting roles.
+			// Get rid of non-existing roles.
 			foreach ($roles as $k => $v) {
 				if (!$wp_roles->is_role($v)) {
 					unset($k);
@@ -252,10 +251,10 @@ final class Authorize
 	 *
 	 * Returns empty string if not found.
 	 *
-	 * @param int $uid wordpress user id
-	 * @return array roles, empty if none found
+	 * @param int $uid WordPress user id
+	 * @return string[] roles, empty if none found
 	 */
-	private function authLdap_user_role($uid)
+	private function authLdap_user_role($uid): array
 	{
 		global $wpdb, $wp_roles;
 
@@ -273,7 +272,7 @@ final class Authorize
 		$editable_roles = $wp_roles->roles;
 
 		// By using this approach we are now using the order of the roles from the WP_Roles object
-		// and not from the capabilities any more.
+		// and not from the capabilities anymore.
 		$userroles = array_keys(array_intersect_key($editable_roles, $usercapabilities));
 
 		$this->logger->log(sprintf(

--- a/src/Authorize.php
+++ b/src/Authorize.php
@@ -1,0 +1,316 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap;
+
+use Exception;
+use Org_Heigl\AuthLdap\Value\DefaultRole;
+use Org_Heigl\AuthLdap\Value\GroupAttribute;
+use Org_Heigl\AuthLdap\Value\GroupBase;
+use Org_Heigl\AuthLdap\Value\GroupEnabled;
+use Org_Heigl\AuthLdap\Value\GroupFilter;
+use Org_Heigl\AuthLdap\Value\GroupOverUser;
+use Org_Heigl\AuthLdap\Value\Groups;
+use Org_Heigl\AuthLdap\Value\GroupSeparator;
+use Org_Heigl\AuthLdap\Value\UidAttribute;
+use Org_Heigl\AuthLdap\Value\UserFilter;
+use WP_Roles;
+use WP_User;
+
+final class Authorize
+{
+	private LdapList $backend;
+
+	private LoggerInterface $logger;
+
+	private GroupOverUser $groupOverUser;
+
+	private GroupEnabled $groupEnabled;
+
+	private DefaultRole $defaultRole;
+
+	private UserFilter $userFilter;
+
+	private GroupFilter $groupFilter;
+
+	private GroupAttribute $groupAttribute;
+
+	private GroupBase $groupBase;
+
+	private GroupSeparator $groupSeparator;
+
+	private Groups $groups;
+
+	private UidAttribute $uidAttribute;
+
+	public function __construct(
+		LdapList $backend,
+		LoggerInterface $logger,
+		GroupOverUser $groupOverUser,
+		GroupEnabled $groupEnabled,
+		DefaultRole $defaultRole,
+		UserFilter $userFilter,
+		GroupFilter $groupFilter,
+		GroupAttribute $groupAttribute,
+		GroupBase $groupBase,
+		GroupSeparator $groupSeparator,
+		Groups $groups,
+		UidAttribute $uidAttribute
+	) {
+		$this->backend = $backend;
+		$this->logger = $logger;
+		$this->groupOverUser = $groupOverUser;
+		$this->groupEnabled = $groupEnabled;
+		$this->defaultRole = $defaultRole;
+		$this->userFilter = $userFilter;
+		$this->groupFilter = $groupFilter;
+		$this->groupAttribute = $groupAttribute;
+		$this->groupBase = $groupBase;
+		$this->groupSeparator = $groupSeparator;
+		$this->groups = $groups;
+		$this->uidAttribute = $uidAttribute;
+	}
+
+	/**
+	 * @param WP_User $user
+	 * @return false|\WP_Error|WP_User
+	 */
+	public function __invoke(\WP_User $user)
+	{
+		try {
+			$roles = [];
+
+			// we only need this if either LDAP groups are disabled or
+			// if the WordPress role of the user overrides LDAP groups
+			if ($this->groupEnabled->isEnabled() === false || $this->groupOverUser->isEnabled() === false) {
+				$userRoles = $this->authLdap_user_role($user->ID);
+				if ($userRoles !== []) {
+					$roles = array_merge($roles, $userRoles);
+				}
+				// TODO, this needs to be revised, it seems, like authldap is taking only the first role
+				// even if in WP there are assigned multiple.
+			}
+
+			// do LDAP group mapping if needed
+			// (if LDAP groups override wordpress user role, $role is still empty)
+			if (($roles === [] || $this->groupOverUser->isEnabled() === true) && $this->groupEnabled->isEnabled() === true) {
+				// FIXME: add correct parameters
+				$userInfoLdap = $this->backend->search(sprintf(
+					(string) $this->userFilter,
+					$user->user_login,
+				), [(string) $this->uidAttribute, 'dn']);
+				if ($userInfoLdap === []) {
+					$this->logger->log('Retrieving userinfo again failed');
+				}
+				$mappedRoles = $this->authLdap_groupmap($userInfoLdap[0][(string) $this->uidAttribute][0], $userInfoLdap[0]['dn']);
+				if ($mappedRoles !== []) {
+					$roles = $mappedRoles;
+					$this->logger->log('role from group mapping: ' . json_encode($roles));
+				}
+			}
+
+			// if we don't have a role yet, use default role
+			if ($roles === [] && (string)$this->defaultRole !== '') {
+				$this->logger->log('no role yet, set default role');
+				$roles[] = (string) $this->defaultRole;
+			}
+
+			if ($roles === []) {
+				// Sorry, but you are not in any group that is allowed access
+				trigger_error('no group found');
+				$this->logger->log('user is not in any group that is allowed access');
+				return false;
+			}
+
+			$wp_roles = new WP_Roles();
+			// not sure if this is needed, but it can't hurt
+
+			// Get rid of unexisting roles.
+			foreach ($roles as $k => $v) {
+				if (!$wp_roles->is_role($v)) {
+					unset($k);
+				}
+			}
+
+			// check if single role or an empty array provided
+			if ($roles === []) {
+				trigger_error('no group found');
+				$this->logger->log('role is invalid');
+				return false;
+			}
+
+			/**
+			 * Add hook for custom User-Role assignment
+			 *
+			 * @param WP_User $user This user-object will be returned. Can be modified as necessary in the actions.
+			 * @param array $roles
+			 */
+			do_action('authldap_user_roles', $user, $roles);
+
+		} catch (Exception $e) {
+			$this->logger->log($e->getMessage());
+			return false;
+		}
+
+		return $user;
+	}
+
+	/**
+	 * Get LDAP groups for user and map to role
+	 *
+	 * @param string $username
+	 * @param string $dn
+	 * @return array role, empty array if no mapping found, first or all role(s) found otherwise
+	 * @conf array authLDAPGroups, associative array, role => ldap_group
+	 * @conf string authLDAPGroupBase, base dn to look up groups
+	 * @conf string authLDAPGroupAttr, ldap attribute that holds name of group
+	 * @conf string authLDAPGroupFilter, LDAP filter to find groups. can contain %s and %dn% placeholders
+	 */
+	private function authLdap_groupmap($username, $dn)
+	{
+		$authLDAPGroups = $this->sortRolesByCapabilities(
+			$this->groups
+		);
+
+		if (array_filter(array_values($authLDAPGroups)) === []) {
+			$this->logger->log('No group names defined');
+			return [];
+		}
+
+		try {
+			// To allow searches based on the DN instead of the uid, we replace the
+			// string %dn% with the users DN.
+			$this->groupFilter = $this->groupFilter->withDn($dn);
+
+			$this->logger->log(sprintf(
+				'Group Filter: %s',
+				$this->groupFilter
+			));
+			$this->logger->log(sprintf(
+				'Group Base: %s',
+				$this->groupBase
+			));
+
+			$groups = $this->backend->search(sprintf(
+				(string) $this->groupFilter,
+				ldap_escape($username, '', LDAP_ESCAPE_FILTER)
+			), [(string) $this->groupAttribute], $this->groupBase);
+		} catch (Exception $e) {
+			$this->logger->log(sprintf(
+				'Exception getting LDAP group attributes: %s',
+				$e->getMessage()
+			));
+			return [];
+		}
+
+		$grp = [];
+		for ($i = 0; $i < $groups ['count']; $i++) {
+			if ((string) $this->groupAttribute === "dn") {
+				$grp[] = $groups[$i]['dn'];
+			} else {
+				for ($k = 0; $k < $groups[$i][(string) $this->groupAttribute]['count']; $k++) {
+					$grp[] = $groups[$i][(string) $this->groupAttribute][$k];
+				}
+			}
+		}
+
+		$this->logger->log('LDAP groups: ' . json_encode($grp));
+
+		// Check whether the user is member of one of the groups that are
+		// allowed acces to the blog. If the user is not member of one of
+		// The groups throw her out! ;-)
+		$roles = [];
+		foreach ($authLDAPGroups as $key => $val) {
+			$currentGroup = explode((string) $this->groupSeparator, $val);
+			// Remove whitespaces around the group-ID
+			$currentGroup = array_map('trim', $currentGroup);
+			if (0 < count(array_intersect($currentGroup, $grp))) {
+				$roles[] = $key;
+			}
+		}
+
+		// Default: If the user is member of more than one group only the first one
+		// will be taken into account!
+		// This filter allows you to return multiple user roles. WordPress
+		// supports this functionality, but not natively via UI from Users
+		// overview (you need to use a plugin). However, it's still widely used,
+		// for example, by WooCommerce, etc. Use if you know what you're doing.
+		if (apply_filters('authLdap_allow_multiple_roles', false) === false && $roles !== []) {
+			$roles = array_slice($roles, 0, 1);
+		}
+
+		$this->logger->log(sprintf(
+			'Roles from LDAP group: %s',
+			json_encode($roles)
+		));
+
+		return $roles;
+	}
+
+
+	/**
+	 * Get the user's current role
+	 *
+	 * Returns empty string if not found.
+	 *
+	 * @param int $uid wordpress user id
+	 * @return array roles, empty if none found
+	 */
+	private function authLdap_user_role($uid)
+	{
+		global $wpdb, $wp_roles;
+
+		if (!$uid) {
+			return [];
+		}
+
+		/** @var array<string, bool> $usercapabilities */
+		$usercapabilities = get_user_meta($uid, "{$wpdb->prefix}capabilities", true);
+		if (!is_array($usercapabilities)) {
+			return [];
+		}
+
+		/** @var array<string, array{name: string, capabilities: array<mixed>} $editable_roles */
+		$editable_roles = $wp_roles->roles;
+
+		// By using this approach we are now using the order of the roles from the WP_Roles object
+		// and not from the capabilities any more.
+		$userroles = array_keys(array_intersect_key($editable_roles, $usercapabilities));
+
+		$this->logger->log(sprintf(
+			"Existing user's roles: %s",
+			implode(', ', $userroles)
+		));
+
+		return $userroles;
+	}
+
+
+	/**
+	 * Sort the given roles by number of capabilities
+	 *
+	 * @param array $groups
+	 *
+	 * @return array
+	 */
+	private function sortRolesByCapabilities(Groups $groups): array
+	{
+		global $wpdb;
+		$myRoles = get_option($wpdb->get_blog_prefix() . 'user_roles');
+
+		uasort($myRoles, function ($a, $b): int {
+			return count($b['capabilities']) <=> count($a['capabilities']);
+		});
+
+		$return = [];
+
+		foreach ($myRoles as $key => $role) {
+			if ($groups->has($key)) {
+				$return[$key] = $groups->get($key);
+			}
+		}
+
+		$this->logger->log(print_r($return, true));
+
+		return $return;
+	}
+}

--- a/src/LdapList.php
+++ b/src/LdapList.php
@@ -31,6 +31,7 @@ use Exception;
 use Org_Heigl\AuthLdap\Exception\Error;
 use Org_Heigl\AuthLdap\Exception\SearchUnsuccessfull;
 use Org_Heigl\AuthLdap\Manager\Ldap;
+use Org_Heigl\AuthLdap\Wrapper\LdapInterface;
 
 class LdapList
 {

--- a/src/LoggedInUserToWpUser.php
+++ b/src/LoggedInUserToWpUser.php
@@ -189,8 +189,12 @@ final class LoggedInUserToWpUser
 				// TODO: Refactor call to wp_update_user
 				$userid = wp_update_user($user_info);
 			} else {
-				// new wordpress account will be created
+				// new WordPress account will be created
 				$this->logger->log('The LDAP user does not have an entry in the WP-Database, a new WP account will be created');
+				// If we do not set an empty role here, the default mechanism of WordPress
+				// takes over and adds the default role here.
+				// We make sur eto handle that in the Authorize-file later.
+				$user_info['role'] = '';
 				// TODO: Refactor call to wp_insert_user
 				$userid = wp_insert_user($user_info);
 			}

--- a/src/LoggedInUserToWpUser.php
+++ b/src/LoggedInUserToWpUser.php
@@ -1,0 +1,230 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap;
+
+use Exception;
+use Org_Heigl\AuthLdap\Value\CachePassword;
+use Org_Heigl\AuthLdap\Value\DoNotOverwriteNonLdapUsers;
+use Org_Heigl\AuthLdap\Value\LoggedInUser;
+use Org_Heigl\AuthLdap\Value\MailAttribute;
+use Org_Heigl\AuthLdap\Value\NameAttribute;
+use Org_Heigl\AuthLdap\Value\ReadLdapAsUser;
+use Org_Heigl\AuthLdap\Value\SecondNameAttribute;
+use Org_Heigl\AuthLdap\Value\UidAttribute;
+use Org_Heigl\AuthLdap\Value\UserFilter;
+use Org_Heigl\AuthLdap\Value\WebAttribute;
+use UnexpectedValueException;
+use WP_User;
+
+final class LoggedInUserToWpUser
+{
+	private LdapList $backend;
+
+	private LoggerInterface $logger;
+
+	private UserFilter $userFilter;
+
+	private	ReadLdapAsUser $readLdapAsUser;
+
+	private NameAttribute $nameAttribute;
+
+	private SecondNameAttribute $secondNameAttribute;
+
+	private MailAttribute $mailAttribute;
+
+	private UidAttribute $uidAttribute;
+
+	private WebAttribute $webAttribute;
+
+	private DoNotOverwriteNonLdapUsers $doNotOverwriteNonLdapUsers;
+
+	private CachePassword $cachePassword;
+
+	public function __construct(
+		LdapList $backend,
+		LoggerInterface $logger,
+		UserFilter $userFilter,
+		ReadLdapAsUser $userRead,
+		NameAttribute $nameAttribute,
+		SecondNameAttribute $secondNameAttribute,
+		MailAttribute $mailAttribute,
+		UidAttribute $uidAttribute,
+		WebAttribute $webAttribute,
+		DoNotOverwriteNonLdapUsers $doNotOverwriteNonLdapUsers,
+		CachePassword $cachePassword,
+	) {
+		$this->backend = $backend;
+		$this->logger = $logger;
+		$this->userFilter = $userFilter;
+		$this->readLdapAsUser = $userRead;
+		$this->nameAttribute = $nameAttribute;
+		$this->secondNameAttribute = $secondNameAttribute;
+		$this->mailAttribute = $mailAttribute;
+		$this->uidAttribute = $uidAttribute;
+		$this->webAttribute = $webAttribute;
+		$this->doNotOverwriteNonLdapUsers = $doNotOverwriteNonLdapUsers;
+		$this->cachePassword = $cachePassword;
+	}
+
+	/**
+	 * @param LoggedInUser $loggedInUser
+	 * @return WP_User|false;
+	 */
+	public function __invoke(LoggedInUser $loggedInUser)
+	{
+		try {
+			// Make optional querying from the admin account #213
+			if (! $this->readLdapAsUser->isEnabled()) {
+				// Rebind with the default credentials after the user has been loged in
+				// Otherwise the credentials of the user trying to login will be used
+				// This fixes #55
+				$this->logger->log('Rebinding with default credentials');
+				$this->backend->bind();
+			}
+
+			$attributes = array_values(
+				array_filter(
+					apply_filters(
+						'authLdap_filter_attributes',
+						[
+							(string)$this->nameAttribute,
+							(string)$this->secondNameAttribute,
+							(string)$this->mailAttribute,
+							(string)$this->webAttribute,
+							(string)$this->uidAttribute,
+						]
+					)
+				)
+			);
+
+			try {
+				$attribs = $this->backend->search(
+					sprintf((string)$this->userFilter, $loggedInUser->getUsername()),
+					$attributes
+				);
+				// First get all the relevant group informations so we can see if
+				// whether have been changes in group association of the user
+				if (!isset($attribs[0]['dn'])) {
+					$this->logger->log('could not get user attributes from LDAP');
+					throw new UnexpectedValueException('dn has not been returned');
+				}
+				if (!isset($attribs[0][strtolower((string)$this->uidAttribute)][0])) {
+					$this->logger->log('could not get user attributes from LDAP');
+					throw new UnexpectedValueException('The user-ID attribute has not been returned');
+				}
+
+				$dn = $attribs[0]['dn'];
+				$realuid = $attribs[0][strtolower((string)$this->uidAttribute)][0];
+			} catch (Exception $e) {
+				$this->logger->log('Exception getting LDAP user: ' . $e->getMessage());
+				return false;
+			}
+
+			// TODO: Refactor
+			$uid = authLdap_get_uid($realuid);
+
+			// This fixes #172
+			if (true === $this->doNotOverwriteNonLdapUsers->isEnabled()) {
+				// TODO: Refactor
+				if (get_userdata($uid) && !get_user_meta($uid, 'authLDAP')) {
+					return null;
+				}
+			}
+
+			// now, lets update some user details
+			$user_info = [];
+			$user_info['user_login'] = $realuid;
+			$user_info['user_email'] = '';
+			$user_info['user_nicename'] = '';
+
+			// first name
+			if (isset($attribs[0][strtolower((string)$this->nameAttribute)][0])) {
+				$user_info['first_name'] = $attribs[0][strtolower((string)$this->nameAttribute)][0];
+			}
+
+			// last name
+			if (isset($attribs[0][strtolower((string)$this->secondNameAttribute)][0])) {
+				$user_info['last_name'] = $attribs[0][strtolower((string)$this->secondNameAttribute)][0];
+			}
+
+			// mail address
+			if (isset($attribs[0][strtolower((string)$this->mailAttribute)][0])) {
+				$user_info['user_email'] = $attribs[0][strtolower((string)$this->mailAttribute)][0];
+			}
+
+			// website
+			if (isset($attribs[0][strtolower((string)$this->webAttribute)][0])) {
+				$user_info['user_url'] = $attribs[0][strtolower((string)$this->webAttribute)][0];
+			}
+			// display name, nickname, nicename
+			if (array_key_exists('first_name', $user_info)) {
+				$user_info['display_name'] = $user_info['first_name'];
+				$user_info['nickname'] = $user_info['first_name'];
+				// TODO: Refactor sanitize_title_with_dashes
+				$user_info['user_nicename'] = sanitize_title_with_dashes($user_info['first_name']);
+				if (array_key_exists('last_name', $user_info)) {
+					$user_info['display_name'] .= ' ' . $user_info['last_name'];
+					$user_info['nickname'] .= ' ' . $user_info['last_name'];
+					// TODO: Refactor sanitize_title_with_dashes
+					$user_info['user_nicename'] .= '_' . sanitize_title_with_dashes($user_info['last_name']);
+				}
+			}
+			$user_info['user_nicename'] = substr($user_info['user_nicename'], 0, 50);
+
+			// optionally store the password into the wordpress database
+			if ($this->cachePassword->isEnabled()) {
+				// Password will be hashed inside wp_update_user or wp_insert_user
+				$user_info['user_pass'] = $loggedInUser->getPassword();
+			} else {
+				// clear the password
+				$user_info['user_pass'] = '';
+			}
+
+			// add uid if user exists
+			if ($uid) {
+				// found user in the database
+				$this->logger->log('The LDAP user has an entry in the WP-Database');
+				$user_info['ID'] = $uid;
+				unset($user_info['display_name'], $user_info['nickname']);
+				// TODO: Refactor call to wp_update_user
+				$userid = wp_update_user($user_info);
+			} else {
+				// new wordpress account will be created
+				$this->logger->log('The LDAP user does not have an entry in the WP-Database, a new WP account will be created');
+				// TODO: Refactor call to wp_insert_user
+				$userid = wp_insert_user($user_info);
+			}
+
+			// if the user exists, wp_insert_user will update the existing user record
+			if (is_wp_error($userid)) {
+				$this->logger->log(sprintf(
+					'Error creating user: %s',
+					$userid->get_error_message()
+				));
+				trigger_error(sprintf(
+					'Error creating user: %s',
+					$userid->get_error_message()
+				));
+				return false;
+			}
+
+			/**
+			 * Add hook for custom updates
+			 *
+			 * @param int $userid User ID.
+			 * @param array $attribs [0] Attributes retrieved from LDAP for the user.
+			 */
+			do_action('authLdap_login_successful', $userid, $attribs[0]);
+
+			$this->logger->log('user id = ' . $userid);
+
+			// flag the user as an ldap user so we can hide the password fields in the user profile
+			update_user_meta($userid, 'authLDAP', true);
+
+			return new \WP_User($userid);
+		} catch (Exception $exception) {
+			$this->logger->log($exception->getMessage());
+			return false;
+		}
+	}
+}

--- a/src/Logger.php
+++ b/src/Logger.php
@@ -1,0 +1,39 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap;
+
+final class Logger implements LoggerInterface
+{
+	private $debug;
+
+	/**
+	 * @var false|resource
+	 */
+	private $fh = false;
+
+	public function __construct(bool $debug = false)
+	{
+		$this->debug = $debug;
+//		$this->fh = fopen('php://stderr', 'w');
+	}
+	public function log(string $message): void
+	{
+		if (! $this->debug) {
+			return;
+		}
+
+		if ($this->fh !== false) {
+			fwrite($this->fh, '[AuthLDAP] ' . $message . PHP_EOL);
+		}
+		error_log('[AuthLDAP] ' . $message, 0);
+	}
+
+	public function __destruct()
+	{
+		if ($this->fh === false) {
+			return;
+		}
+
+		fclose($this->fh);
+	}
+}

--- a/src/LoggerInterface.php
+++ b/src/LoggerInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Org_Heigl\AuthLdap;
+
+interface LoggerInterface
+{
+	public function log(string $message): void;
+}

--- a/src/Value/CachePassword.php
+++ b/src/Value/CachePassword.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class CachePassword
+{
+	private bool $enabled;
+	private function __construct(bool $enabled) {
+		$this->enabled = $enabled;
+	}
+
+	public static function fromString(string $enabled = ''): self
+	{
+		return new self(filter_var($enabled, FILTER_VALIDATE_BOOLEAN));
+	}
+
+	public function isEnabled(): bool
+	{
+		return $this->enabled;
+	}
+	public function __toString(): string
+	{
+		return $this->enabled ? 'true': 'false';
+	}
+}

--- a/src/Value/DefaultRole.php
+++ b/src/Value/DefaultRole.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class DefaultRole
+{
+	private string $defaultRole;
+	private function __construct(string $defaultRole) {
+		$this->defaultRole = $defaultRole;
+	}
+
+	public static function fromString(string $defaultRole = ''): self
+	{
+		return new self($defaultRole);
+	}
+
+	public function __toString(): string
+	{
+		return $this->defaultRole;
+	}
+}

--- a/src/Value/DoNotOverwriteNonLdapUsers.php
+++ b/src/Value/DoNotOverwriteNonLdapUsers.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class DoNotOverwriteNonLdapUsers
+{
+	private bool $enabled;
+	private function __construct(bool $enabled) {
+		$this->enabled = $enabled;
+	}
+
+	public static function fromString(string $enabled = ''): self
+	{
+		return new self(filter_var($enabled, FILTER_VALIDATE_BOOLEAN));
+	}
+
+	public function isEnabled(): bool
+	{
+		return $this->enabled;
+	}
+	public function __toString(): string
+	{
+		return $this->enabled ? 'true': 'false';
+	}
+}

--- a/src/Value/Enabled.php
+++ b/src/Value/Enabled.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class Enabled
+{
+	private bool $enabled;
+	private function __construct(bool $enabled) {
+		$this->enabled = $enabled;
+	}
+
+	public static function fromString(string $enabled = ''): self
+	{
+		return new self(filter_var($enabled, FILTER_VALIDATE_BOOLEAN));
+	}
+
+	public function isEnabled(): bool
+	{
+		return $this->enabled;
+	}
+	public function __toString(): string
+	{
+		return $this->enabled ? 'true': 'false';
+	}
+}

--- a/src/Value/GroupAttribute.php
+++ b/src/Value/GroupAttribute.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class GroupAttribute
+{
+	private string $groupAttribute;
+	private function __construct(string $groupAttribute) {
+		$this->groupAttribute = $groupAttribute;
+	}
+
+	public static function fromString(string $groupAttribute = ''): self
+	{
+		return new self($groupAttribute);
+	}
+
+	public function __toString(): string
+	{
+		if ($this->groupAttribute === '') {
+			return 'gidnumber';
+		}
+
+		return strtolower($this->groupAttribute);
+	}
+}

--- a/src/Value/GroupBase.php
+++ b/src/Value/GroupBase.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class GroupBase
+{
+	private string $groupBase;
+	private function __construct(string $groupBase) {
+		$this->groupBase = $groupBase;
+	}
+
+	public static function fromString(string $groupBase = ''): self
+	{
+		return new self($groupBase);
+	}
+
+	public function __toString(): string
+	{
+		return $this->groupBase;
+	}
+}

--- a/src/Value/GroupEnabled.php
+++ b/src/Value/GroupEnabled.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class GroupEnabled
+{
+	private bool $enabled;
+	private function __construct(bool $enabled) {
+		$this->enabled = $enabled;
+	}
+
+	public static function fromString(string $enabled = ''): self
+	{
+		return new self(filter_var($enabled, FILTER_VALIDATE_BOOLEAN));
+	}
+
+	public function isEnabled(): bool
+	{
+		return $this->enabled;
+	}
+	public function __toString(): string
+	{
+		return $this->enabled ? 'true': 'false';
+	}
+}

--- a/src/Value/GroupFilter.php
+++ b/src/Value/GroupFilter.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class GroupFilter
+{
+	private string $groupFilter;
+
+	private string $dn;
+	private function __construct(string $groupFilter, string $dn = '') {
+		$this->groupFilter = $groupFilter;
+		$this->dn = ldap_escape($dn, '', LDAP_ESCAPE_FILTER);
+	}
+
+	public function withDn(string $dn): self
+	{
+		return new self($this->groupFilter, $dn);
+	}
+
+	public static function fromString(string $groupFilter = ''): self
+	{
+		return new self($groupFilter);
+	}
+
+	public function __toString(): string
+	{
+		if ($this->groupFilter === '') {
+			return '(&(objectClass=posixGroup)(memberUid=%s))';
+		}
+
+		return str_replace('%dn%', $this->dn, $this->groupFilter);
+	}
+}

--- a/src/Value/GroupOverUser.php
+++ b/src/Value/GroupOverUser.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class GroupOverUser
+{
+	private bool $enabled;
+	private function __construct(bool $enabled) {
+		$this->enabled = $enabled;
+	}
+
+	public static function fromString(string $enabled = ''): self
+	{
+		return new self(filter_var($enabled, FILTER_VALIDATE_BOOLEAN));
+	}
+
+	public function isEnabled(): bool
+	{
+		return $this->enabled;
+	}
+	public function __toString(): string
+	{
+		return $this->enabled ? 'true': 'false';
+	}
+}

--- a/src/Value/GroupSeparator.php
+++ b/src/Value/GroupSeparator.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class GroupSeparator
+{
+	private string $groupSeparator;
+	private function __construct(string $groupSeparator) {
+		$this->groupSeparator = $groupSeparator;
+	}
+
+	public static function fromString(string $groupSeparator = ''): self
+	{
+		return new self($groupSeparator);
+	}
+
+	public function __toString(): string
+	{
+		if ($this->groupSeparator === '') {
+			return ',';
+		}
+
+		return $this->groupSeparator;
+	}
+}

--- a/src/Value/Groups.php
+++ b/src/Value/Groups.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+use Iterator;
+
+final class Groups
+{
+	private array $groups;
+	private function __construct(string...$groups) {
+		$this->groups = $groups;
+	}
+
+	public static function fromArray(array $groups): self
+	{
+		return new self(...$groups);
+	}
+
+	public function has(string $key): bool
+	{
+		return isset($this->groups[$key]);
+	}
+
+	public function get(string $key): string
+	{
+		if (!$this->has($key)) {
+			return '';
+		}
+		return $this->groups[$key];
+	}
+}

--- a/src/Value/LoggedInUser.php
+++ b/src/Value/LoggedInUser.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+use InvalidArgumentException;
+
+final class LoggedInUser
+{
+	private string $username;
+
+	private string $password;
+
+	private function __construct(string $username, string $password) {
+		$this->username = $username;
+		$this->password = $password;
+	}
+
+	/**
+	 * @param mixed $username
+	 */
+	public static function fromUsernameAndPassword(Username $username, Password $password): self
+	{
+		return new self((string) $username, (string) $password);
+	}
+
+	public function getUsername(): string
+	{
+		return $this->username;
+	}
+
+	public function getPassword(): string
+	{
+		return $this->password;
+	}
+}

--- a/src/Value/MailAttribute.php
+++ b/src/Value/MailAttribute.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class MailAttribute
+{
+	private string $mailAttribute;
+	private function __construct(string $mailAttribute) {
+		$this->mailAttribute = $mailAttribute;
+	}
+
+	public static function fromString(string $mailAttribute = ''): self
+	{
+		return new self($mailAttribute);
+	}
+
+	public function __toString(): string
+	{
+		if ($this->mailAttribute === '') {
+			return 'mail';
+		}
+
+		return $this->mailAttribute;
+	}
+}

--- a/src/Value/NameAttribute.php
+++ b/src/Value/NameAttribute.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class NameAttribute
+{
+	private string $nameAttribute;
+	private function __construct(string $nameAttribute) {
+		$this->nameAttribute = $nameAttribute;
+	}
+
+	public static function fromString(string $nameAttribute = ''): self
+	{
+		return new self($nameAttribute);
+	}
+
+	public function __toString(): string
+	{
+		if ($this->nameAttribute === '') {
+			return 'name';
+		}
+
+		return $this->nameAttribute;
+	}
+}

--- a/src/Value/Password.php
+++ b/src/Value/Password.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+use InvalidArgumentException;
+
+final class Password
+{
+	private string $password;
+	private function __construct(string $password) {
+		$this->password = $password;
+	}
+
+	/**
+	 * @param mixed $password
+	 */
+	public static function fromMixed($password): self
+	{
+		global $error;
+		if (! is_string($password)) {
+			throw new InvalidArgumentException('provided password is not a string');
+		}
+		if ($password === '') {
+			$error =  __('<strong>Error</strong>: The password field is empty.');
+			throw new InvalidArgumentException('No password provided');
+		}
+
+		// Remove slashes as noted on https://github.com/heiglandreas/authLdap/issues/108
+		return new self(stripslashes_deep($password));
+	}
+
+	public function __toString(): string
+	{
+		return $this->password;
+	}
+}

--- a/src/Value/ReadLdapAsUser.php
+++ b/src/Value/ReadLdapAsUser.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class ReadLdapAsUser
+{
+	private bool $enabled;
+	private function __construct(bool $enabled) {
+		$this->enabled = $enabled;
+	}
+
+	public static function fromString(string $enabled = ''): self
+	{
+		return new self(filter_var($enabled, FILTER_VALIDATE_BOOLEAN));
+	}
+
+	public function isEnabled(): bool
+	{
+		return $this->enabled;
+	}
+	public function __toString(): string
+	{
+		return $this->enabled ? 'true': 'false';
+	}
+}

--- a/src/Value/SecondNameAttribute.php
+++ b/src/Value/SecondNameAttribute.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class SecondNameAttribute
+{
+	private string $secondNameAttribute;
+	private function __construct(string $secondNameAttribute) {
+		$this->secondNameAttribute = $secondNameAttribute;
+	}
+
+	public static function fromString(string $secondNameAttribute = ''): self
+	{
+		return new self($secondNameAttribute);
+	}
+
+	public function __toString(): string
+	{
+		if ($this->secondNameAttribute === '') {
+			return '';
+		}
+
+		return $this->secondNameAttribute;
+	}
+}

--- a/src/Value/UidAttribute.php
+++ b/src/Value/UidAttribute.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class UidAttribute
+{
+	private string $uidAttribute;
+	private function __construct(string $uidAttribute) {
+		$this->uidAttribute = $uidAttribute;
+	}
+
+	public static function fromString(string $uidAttribute = ''): self
+	{
+		return new self($uidAttribute);
+	}
+
+	public function __toString(): string
+	{
+		if ($this->uidAttribute === '') {
+			return 'uid';
+		}
+
+		return strtolower($this->uidAttribute);
+	}
+}

--- a/src/Value/UserFilter.php
+++ b/src/Value/UserFilter.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class UserFilter
+{
+	private string $userFilter;
+	private function __construct(string $userFilter) {
+		$this->userFilter = $userFilter;
+	}
+
+	public static function fromString(string $userFilter = ''): self
+	{
+		return new self($userFilter);
+	}
+
+	public function __toString(): string
+	{
+		if ($this->userFilter === '') {
+			return '(uid=%s)';
+		}
+
+		return $this->userFilter;
+	}
+}

--- a/src/Value/Username.php
+++ b/src/Value/Username.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+use InvalidArgumentException;
+
+final class Username
+{
+	private string $username;
+	private function __construct(string $username) {
+		$this->username = $username;
+	}
+
+	/**
+	 * @param mixed $username
+	 */
+	public static function fromMixed($username): self
+	{
+		if (! is_string($username)) {
+			throw new InvalidArgumentException('No valid username provided');
+		}
+		if ($username === '') {
+			throw new InvalidArgumentException('No username provided');
+		}
+
+		return new self($username);
+	}
+
+	public function __toString(): string
+	{
+		return $this->username;
+	}
+}

--- a/src/Value/WebAttribute.php
+++ b/src/Value/WebAttribute.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class WebAttribute
+{
+	private string $webAttribute;
+	private function __construct(string $webAttribute) {
+		$this->webAttribute = $webAttribute;
+	}
+
+	public static function fromString(string $webAttribute = ''): self
+	{
+		return new self($webAttribute);
+	}
+
+	public function __toString(): string
+	{
+		if ($this->webAttribute === '') {
+			return '';
+		}
+
+		return $this->webAttribute;
+	}
+}


### PR DESCRIPTION
This way we can for one thing easier test the different parts of the
plugin and also at a later stage completely skip the authentication part
and only use the plugin for authorization - meaning group/role
assignements