### PR TITLE
Fix broken admin interface

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -172,7 +172,7 @@ function authLdap_options_panel()
 	$authLDAPMailAttr = authLdap_get_option('MailAttr');
 	$authLDAPUidAttr = authLdap_get_option('UidAttr');
 	$authLDAPWebAttr = authLdap_get_option('WebAttr');
-	$authLDAPGroups = authLdap_get_option('Groups');
+	$authLDAPGroups = (array) authLdap_get_option('Groups');
 	$authLDAPGroupSeparator = authLdap_get_option('GroupSeparator');
 	$authLDAPDebug = authLdap_get_option('Debug');
 	$authLDAPGroupBase = authLdap_get_option('GroupBase');

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === authLdap ===
 Contributors: heiglandreas
-Tags: ldap, auth, authentication, active directory, AD, openLDAP, Open Directory
+Tags: ldap, auth, authentication, active directory, openLDAP, Open Directory
 Requires at least: 2.5.0
 Tested up to: 6.7.0
 Requires PHP: 7.4


### PR DESCRIPTION
For whatever reason the admin interface had an issue with an empty groups-setup as that was interpreted as string instead of an empty array.

Therefore we convert the empty string into an empty array.