### PR TITLE
Add php-lint

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,17 +12,14 @@ jobs:
       PORT_LDAPS: 6363
       LDAP_ADMIN_PASSWORD: ${{ secrets.LDAP_ADMIN_PASSWORD }}
       LDAP_LOG_LEVEL: 0
-    strategy:
-      matrix:
-        # operating-system: [ubuntu-latest, windows-latest, macos-latest]
-        php-versions: [ '8.4' ]
-    name: Test on ${{ matrix.php-versions }}
+
+    name: Check compatibility with 7.4
     steps:
       - uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: '8.3'
           extensions: ldap
       - name: install dependencies
         run: composer install
@@ -32,26 +29,13 @@ jobs:
         run: ./vendor/bin/phpcs --standard=phpcs-version-check.xml
   lint:
     runs-on: ubuntu-latest
-    env:
-      PORT_LDAP: 3389
-      PORT_LDAPS: 6363
-      LDAP_ADMIN_PASSWORD: ${{ secrets.LDAP_ADMIN_PASSWORD }}
-      LDAP_LOG_LEVEL: 0
     strategy:
       matrix:
         # operating-system: [ubuntu-latest, windows-latest, macos-latest]
         php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
-    name: Test on ${{ matrix.php-versions }}
+    name: Lint on ${{ matrix.php-versions }}
     steps:
       - uses: actions/checkout@v4
-      - uses: jpribyl/action-docker-layer-caching@v0.1.1
-        continue-on-error: true
-      - name: Build the docker compose stack
-        run: docker compose -f compose.yml up -d db openldap
-      - name: Check running containers
-        run: docker ps -a
-      - name: Check logs
-        run: docker compose logs openldap
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -59,9 +43,9 @@ jobs:
           extensions: ldap
       - name: install dependencies
         run: |
-          composer require --dev jakub-onderka/php-parallel-lint
+          composer require --dev php-parallel-lint/php-parallel-lint
       - name: Lint source files
-        run: ./vendor/bin/parallel-lint . --exclude vendor
+        run: ./vendor/bin/parallel-lint . --exclude vendor --exclude wordbless
   test:
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         # operating-system: [ubuntu-latest, windows-latest, macos-latest]
-        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+        php-versions: [ '8.4' ]
     name: Test on ${{ matrix.php-versions }}
     steps:
       - uses: actions/checkout@v4
@@ -28,8 +28,40 @@ jobs:
         run: composer install
       - name: install tools
         run: composer require --dev phpcompatibility/php-compatibility
-      - name: Run COmpatibility check
+      - name: Run Compatibility check
         run: ./vendor/bin/phpcs --standard=phpcs-version-check.xml
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      PORT_LDAP: 3389
+      PORT_LDAPS: 6363
+      LDAP_ADMIN_PASSWORD: ${{ secrets.LDAP_ADMIN_PASSWORD }}
+      LDAP_LOG_LEVEL: 0
+    strategy:
+      matrix:
+        # operating-system: [ubuntu-latest, windows-latest, macos-latest]
+        php-versions: [ '7.4', '8.0', '8.1', '8.2', '8.3', '8.4' ]
+    name: Test on ${{ matrix.php-versions }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+        continue-on-error: true
+      - name: Build the docker compose stack
+        run: docker compose -f compose.yml up -d db openldap
+      - name: Check running containers
+        run: docker ps -a
+      - name: Check logs
+        run: docker compose logs openldap
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: ldap
+      - name: install dependencies
+        run: |
+          composer require --dev jakub-onderka/php-parallel-lint
+      - name: Lint source files
+        run: ./vendor/bin/parallel-lint . --exclude vendor
   test:
     runs-on: ubuntu-latest
     env:

--- a/phpcs-version-check.xml
+++ b/phpcs-version-check.xml
@@ -7,7 +7,7 @@
 
 	<file>./src</file>
 	<file>./tests</file>
-	<file>./authldap.php</file>
+	<file>./authLdap.php</file>
 
 	<config name="installed_paths" value="vendor/phpcompatibility/php-compatibility" />
 	<config name="testVersion" value="7.4-"/>

--- a/src/LoggedInUserToWpUser.php
+++ b/src/LoggedInUserToWpUser.php
@@ -53,7 +53,7 @@ final class LoggedInUserToWpUser
 		UidAttribute $uidAttribute,
 		WebAttribute $webAttribute,
 		DoNotOverwriteNonLdapUsers $doNotOverwriteNonLdapUsers,
-		CachePassword $cachePassword,
+		CachePassword $cachePassword
 	) {
 		$this->backend = $backend;
 		$this->logger = $logger;

--- a/tests/Manager/LDAPBaseTest.php
+++ b/tests/Manager/LDAPBaseTest.php
@@ -158,9 +158,9 @@ class LDAPBaseTest extends TestCase
         ));
 
 		$this->wrapper->expects($this->exactly(2))
-			->method('bind')
+			->method('bind')->with(
 				['cn=admin,dc=example,dc=org', 'insecure'],
-				['foo', 'password'],
+				['foo', 'password']
 			)
 			->willReturnOnConsecutiveCalls(true, true);
 		$this->wrapper->expects($this->once())->method('search')->with(


### PR DESCRIPTION
THis allows me to find linting errors when ran against the different PHP-versions to not run into the issue that happened when using the sensitiveparameter attribute on PHP7.4