### PR TITLE
Fix PHP7.4 issue

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -65,6 +65,7 @@ require_once __DIR__ . '/src/Value/GroupBase.php';
 require_once __DIR__ . '/src/Value/GroupEnabled.php';
 require_once __DIR__ . '/src/Value/GroupFilter.php';
 require_once __DIR__ . '/src/Value/GroupOverUser.php';
+require_once __DIR__ . '/src/Value/GroupAssignment.php';
 require_once __DIR__ . '/src/Value/Groups.php';
 require_once __DIR__ . '/src/Value/GroupSeparator.php';
 require_once __DIR__ . '/src/Value/MailAttribute.php';

--- a/features/log in using no groups at all.feature
+++ b/features/log in using no groups at all.feature
@@ -15,6 +15,40 @@ Feature: Log in without group assignment
 		And a new WordPress user "ldapuser" was created with name "LDAP User" and email "ldapuser@example.com"
 		And the WordPress user "ldapuser" is member of role "subscriber"
 
+	Scenario: Login without group assignment with an empty group setup
+		Given a default configuration
+		And configuration value "GroupEnable" is set to "false"
+		And configuration value "Groups" is set to ""
+		And configuration value "DefaultRole" is set to "subscriber"
+		And an LDAP user "ldapuser" with name "LDAP User", password "P@ssw0rd" and email "ldapuser@example.com" exists
+		And an LDAP group "ldapgroup" exists
+		And LDAP user "ldapuser" is member of LDAP group "ldapgroup"
+		And a WordPress user "wordpressuser" with name "WordPress_User" and email "wordpressuser@example.com" exists
+		And a WordPress role "wordpressrole" exists
+		And WordPress user "wordpressuser" has role "wordpressrole"
+		And a WordPress user "ldapuser" does not exist
+		When user "ldapuser" logs in with password "P@ssw0rd"
+		Then the login suceeds
+		And a new WordPress user "ldapuser" was created with name "LDAP User" and email "ldapuser@example.com"
+		And the WordPress user "ldapuser" is member of role "subscriber"
+
+	Scenario: Login without group assignment with a different kind of empty group setup
+		Given a default configuration
+		And configuration value "GroupEnable" is set to "false"
+		And configuration value "Groups" is set to "administrator=" and "editor="
+		And configuration value "DefaultRole" is set to "subscriber"
+		And an LDAP user "ldapuser" with name "LDAP User", password "P@ssw0rd" and email "ldapuser@example.com" exists
+		And an LDAP group "ldapgroup" exists
+		And LDAP user "ldapuser" is member of LDAP group "ldapgroup"
+		And a WordPress user "wordpressuser" with name "WordPress_User" and email "wordpressuser@example.com" exists
+		And a WordPress role "wordpressrole" exists
+		And WordPress user "wordpressuser" has role "wordpressrole"
+		And a WordPress user "ldapuser" does not exist
+		When user "ldapuser" logs in with password "P@ssw0rd"
+		Then the login suceeds
+		And a new WordPress user "ldapuser" was created with name "LDAP User" and email "ldapuser@example.com"
+		And the WordPress user "ldapuser" is member of role "subscriber"
+
 	Scenario: Login with group assignment to multiple groups where only first wordpress group is used
 		Given a default configuration
 		And configuration value "GroupEnable" is set to "true"

--- a/src/Value/GroupAssignment.php
+++ b/src/Value/GroupAssignment.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+use InvalidArgumentException;
+
+final class GroupAssignment
+{
+	private string $wordPressRole;
+
+	private string $ldapGroups;
+
+	private function __construct(string $wordPressRole, string $ldapGroups)
+	{
+		$this->wordPressRole = $wordPressRole;
+		$this->ldapGroups = $ldapGroups;
+	}
+
+	/**
+	 * @param mixed $username
+	 */
+	public static function fromKeyValue(string $key, string $value): self
+	{
+		return new self($key, trim($value));
+	}
+
+	public function getRole(): string
+	{
+		return $this->wordPressRole;
+	}
+
+	public function getGroups(): string
+	{
+		return $this->ldapGroups;
+	}
+}

--- a/src/Value/Groups.php
+++ b/src/Value/Groups.php
@@ -9,14 +9,20 @@ use Iterator;
 final class Groups
 {
 	private array $groups;
-	private function __construct(string ...$groups)
+	private function __construct(GroupAssignment ...$groups)
 	{
-		$this->groups = $groups;
+		foreach ($groups as $group) {
+			$this->groups[$group->getRole()] = $group->getGroups();
+		}
 	}
 
 	public static function fromArray(array $groups): self
 	{
-		return new self(...$groups);
+		$assignements = [];
+		foreach ($groups as $key => $group) {
+			$assignements[] = GroupAssignment::fromKeyValue($key, $group);
+		}
+		return new self(...$assignements);
 	}
 
 	public function has(string $key): bool

--- a/view/admin.phtml
+++ b/view/admin.phtml
@@ -73,7 +73,7 @@
                 </tr>
                 <tr>
                     <th>
-                        <label for="authLDAPCachePW">Save entered passwords in the wordpress user table?</label>
+                        <label for="authLDAPCachePW">Save entered passwords in the WordPress user table?</label>
                     </th>
                     <td>
                         <input type="checkbox" name="authLDAPCachePW" id="authLDAPCachePW" value="1"<?php echo $tPWChecked; ?>/>
@@ -81,12 +81,12 @@
                 </tr>
                 <tr>
                     <th>
-                        <label for="authLDAPGroupEnable">Map LDAP Groups to wordpress Roles?</label>
+                        <label for="authLDAPGroupEnable">Map LDAP Groups to WordPress Roles?</label>
                     </th>
                     <td>
                         <input type="checkbox" name="authLDAPGroupEnable" id="authLDAPGroupEnable" value="1"<?php echo $tGroupChecked; ?>/>
                         <p class="description">
-                            Search LDAP for user's groups and map to Wordpress Roles.
+                            Search LDAP for user's groups and map to WordPress Roles.
                         </p>
                     </td>
                 </tr>
@@ -319,7 +319,7 @@
                     <td>
                         <input type="checkbox" name="authLDAPGroupOverUser" id="authLDAPGroupOverUser" value="1"<?php echo esc_attr($tGroupOverUserChecked); ?>/>
                         <p class="description">
-                            If role determined by LDAP Group differs from existing Wordpress User's role, use LDAP Group.
+                            If role determined by LDAP Group differs from existing WordPress User's role, use LDAP Group.
                         </p>
                     </td>
                 </tr>


### PR DESCRIPTION
In PHP7.4 it wasn't possible to derference associative arrays via the ... operator. This blew up for some users and should be fixed with this commit