### PR TITLE
Experimental Authorization-only mode

### DIFF
--- a/README-AuthZ.md
+++ b/README-AuthZ.md
@@ -1,0 +1,54 @@
+# Authorization-Only (AuthZ) Experimental Settings
+
+Additional settings have been added to leverage authLDAP to map roles for users that are authenticating using something other than the LDAP store.
+
+## Settings
+* **Enable LDAP Group Lookup for 'External' users?** Allows users who are logging in via alternative (non-LDAP/local account) scenarios to have role mappings assigned if their user can be looked up via LDAP.
+* **Allow local accounts when External Users are enabled?** When External users are allowed, also permits local accounts to still work. Without this setting, local accounts will fail the necessary group lookups, causing them to have all roles removed during session initialization.
+
+## User types supported
+1. Standard "Local" (non-LDAP) WordPress accounts
+2. LDAP accounts
+3. Alternative logins (social logins, OIDC, SAML, etc) where the user has an object in WordPress
+   
+   Support for authenticating with these types of accounts must be done via another plugin, and is not native to authLDAP.
+
+authLDAP has always supported a combination of the first two user types. This document assumes you want to add support for the third.
+
+## Requirements
+### LDAP Requirements
+- The LDAP directory must contain an entry for the user.
+- The user must be able to be searched for using the same method that LDAP users are distinguished.
+  - If the user cannot be found this way, they will receive the default role (if any) that your LDAP users also receive.
+
+### Login Requirements
+- The alternative authentication method must present the username the same way that WordPress would expect it, or your other plugin(s) must otherwise be able to rationalize the information to a WordPress account.
+  - Making this work is an exercise for the reader, and beyond the scope of this document.
+- Your authentication chain must be configured to limit the set of valid users, or anyone with an account can log in and get the default role.
+
+### authLDAP Requirements
+- Role assignment based on group membership ("Groups for Roles") is the only intended use case for these options. Without them, this is kind of worthless.
+- Default Role for LDAP users will also apply to the "External" users that log in
+
+## Configuration Scenarios
+In all of the scenarios below, we have 4 example users:
+1. **localadmin** - the initial WordPress account, with Administrator access assigned in the WordPress database. This account is not present in LDAP at all.
+2. **ldapadmin** - an LDAP user that is part of a group mapped to the Administrator role
+3. **samluser** - a user logging in via the SAML protocol, who is also present in the LDAP database and a member of the same group as ldapadmin
+4. **othersamluser** - another user logging in via the SAML protocol, who is absent from the LDAP database
+
+Regardless of settings changes, behavior surrounding the **ldapamin** account should remain unchanged.
+
+By enabling External accounts (via the first new Experimental setting), the **samluser** account would also receive Administrator upon login - even if the WordPress database has them desginated with another setting. That role will be updated in the database on every login.
+
+The **othersamluser** account will receive the default role for users defined by authLDAP (or be denied access), regardless of what is defined in the WordPress database. Again, this will be updated on each login. In the case where Default Role is set to None (deny access), the database is not updated with new roles if the user already exists.
+
+The **localadmin** account will behave similarly, **EXCEPT** when the "Allow local accounts when External Users are enabled" setting is checked. With this option turned on, the roles for the local WP account will be honored. Please be advised that if **localadmin** logs in while this setting is off, their permissions will revert to the default role (or denied access without a database update).
+
+## Recommendations for initial configuration/testing of AuthZ-only
+* Back up your WordPress database to ensure you can roll back. (No seriously - this is a completely experimental feature).
+* Have multiple Administrator accounts so that you can test one without disabling all access.
+* Set the Default Role to "None (deny access)" until you are clear you have a stable configuration.
+  * This ensures that a different Default Role doesn't clobber your existing users.
+  * Generally, this is a good practice anyway, especially if your external authentication is very open.
+* Make sure you have the WordPress command line tool, wp-cli, installed and can actually run it.

--- a/authLdap.php
+++ b/authLdap.php
@@ -352,8 +352,8 @@ function authLdap_login($user, $username, $password, $already_md5 = false)
 	}
 
 	// Set global variable to distinguish LDAP and non-LDAP logins
-	global $isLdapLogin;
-	$isLdapLogin = true;
+	global $authLDAPisLdapLogin;
+	$authLDAPisLdapLogin = true;
 
 	return $loggedInUser;
 }
@@ -386,11 +386,11 @@ function authLdap_login($user, $username, $password, $already_md5 = false)
  */
 function authLdap_authorize_only($loggedInUser, $username)
 {
-	// If $isLdapLogin is true - due to authLdap_login success - just return
+	// If $authLDAPisLdapLogin is true - due to authLdap_login success - just return
 	// the supplied user object and do nothing here
-	global $isLdapLogin;
+	global $authLDAPisLdapLogin;
 
-	if($isLdapLogin == true){
+	if($authLDAPisLdapLogin == true){
 		authLdap_debug('User authenticated via LDAP - skipping LDAP AuthZ and Update');
 		return $loggedInUser;
 	}

--- a/src/Options.php
+++ b/src/Options.php
@@ -35,6 +35,8 @@ class Options
 	public const GROUP_OVER_USER = 'GroupOverUser';
 	public const VERSION = 'Version';
 	public const DO_NOT_OVERWRITE_NON_LDAP_USERS = 'DoNotOverwriteNonLdapUsers';
+	public const EXTERNAL_USERS = 'ExternalUsers';
+	public const LOCAL_WITH_EXTERNAL = 'LocalWithExternal';
 
 	private array $settings = [
 			'Enabled' => false,
@@ -56,6 +58,8 @@ class Options
 			'GroupOverUser' => true,
 			'Version' => 1,
 			'DoNotOverwriteNonLdapUsers' => false,
+			'ExternalUsers' => false,
+			'LocalWithExternal' => false,
 		];
 
 	public function get(string $key)

--- a/src/Value/ExternalUsers.php
+++ b/src/Value/ExternalUsers.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class ExternalUsers
+{
+	private bool $enabled;
+	private function __construct(bool $enabled)
+	{
+		$this->enabled = $enabled;
+	}
+
+	public static function fromString(string $enabled = ''): self
+	{
+		return new self(filter_var($enabled, FILTER_VALIDATE_BOOLEAN));
+	}
+
+	public function isEnabled(): bool
+	{
+		return $this->enabled;
+	}
+	public function __toString(): string
+	{
+		return $this->enabled ? 'true' : 'false';
+	}
+}

--- a/src/Value/LocalWithExternal.php
+++ b/src/Value/LocalWithExternal.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Org_Heigl\AuthLdap\Value;
+
+final class LocalWithExternal
+{
+	private bool $enabled;
+	private function __construct(bool $enabled)
+	{
+		$this->enabled = $enabled;
+	}
+
+	public static function fromString(string $enabled = ''): self
+	{
+		return new self(filter_var($enabled, FILTER_VALIDATE_BOOLEAN));
+	}
+
+	public function isEnabled(): bool
+	{
+		return $this->enabled;
+	}
+	public function __toString(): string
+	{
+		return $this->enabled ? 'true' : 'false';
+	}
+}

--- a/view/admin.phtml
+++ b/view/admin.phtml
@@ -324,6 +324,32 @@
                     </td>
                 </tr>
                 <tr>
+                    <th>
+                        <label for="authLDAPExtUsers">EXPERIMENTAL Enable LDAP Group Lookup for 'External' users?</label>
+                    </th>
+                    <td>
+                        <input type="checkbox" name="authLDAPExternalUsers" id="authLDAPExternalUsers" value="1"<?php echo $tExtChecked; ?>/>
+                        <p class="description">
+                            Shall we try to find the user in LDAP even if they logged in through a different mechanism (SAML, OIDC, social logins, local accounts, etc)? CAUTION: This has the potential to break access for users,
+			                depending on the configuration of other settings.
+                        </p>
+                        <p class="description">This should only be checked if you know what you are doing! THIS WILL TRIGGER EVEN IF LDAP AUTHENTICATION IS DISABLED.</p>
+                        <p class="description">Also of note is that the "User-Read" option will not apply to non-LDAP users.</p>
+                    </td>
+                </tr>
+                <tr>
+                    <th>
+                        <label for="authLDAPLocalWithExternal">EXPERIMENTAL Allow local accounts when External Users are enabled?</label>
+                    </th>
+                    <td>
+                        <input type="checkbox" name="authLDAPLocalWithExternal" id="authLDAPLocalWithExternal" value="1"<?php echo $tLocalWExtChecked; ?>/>
+                        <p class="description">
+                            If in experimental LDAP Group Lookup mode, should local WordPress users be allowed to log in even when they cannot be found in LDAP. This will cause the user to have their configured WP roles.
+                        </p>
+                        <p class="description">This option has no effect if the External users are not permitted.</p>
+                    </td>
+                </tr>
+                <tr>
                     <th scope="row">
                         <label for="authLDAPGroupBase">Group-Base</label>
                     </th>


### PR DESCRIPTION
Add support for Authorization-Only mode:
- Supports a variety of login scenarios when combined with other WP plugins
- Triggered by authLdap_authorize_only function in authLdap.php
- Two new, EXPERIMENTAL settings (booleans) in admin UI (ExternalUsers, LocalWithExternal)
  - Admin UI support already added
  - Added in parallel with other Values definitions in Org_Heigl\AuthLdap\Value namespace
  - Both settings are necessary for continued support of "local database" WP users
- Included additional README file for details

Other changes made in support of this PR:
- Patched a potential data disclosure vulnerability in login flow ($logger->log(var_export($loggedInUser, true));)
- Added support for authLdap_get_server() to "reset" the binding when called
  - Necessary to support "local user" scenario
- Suppress PHP errors being thrown with user DN cannot be found during authorization flow
  - Was causing silent failures in certain test cases

Happy to discuss any of the reasoning used here, make further modifications as necessary, or have this torn apart for further reuse if that's what's needed.