### PR TITLE
Improve error messages

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -44,6 +44,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           tools: phive
+          ini-values: "memory_limit=-1"
       - name: install dependencies
         run: composer install
       - name: install behat

--- a/dockersetup/Dockerfile_wordpress
+++ b/dockersetup/Dockerfile_wordpress
@@ -22,6 +22,8 @@ RUN set -x \
     && docker-php-ext-install mysqli \
     && apt-get purge -y --auto-remove libldap2-dev
 
+RUN echo -n "memory_limit=-1" >> /usr/local/etc/php/conf.d/docker-fpm.ini
+
 WORKDIR /var/www/html
 RUN set -x \
     && curl -o /usr/local/bin/wp https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar \

--- a/src/Manager/Ldap.php
+++ b/src/Manager/Ldap.php
@@ -107,7 +107,11 @@ class Ldap
 			$bind = $this->connection->bind($this->uri->getUsername(), $this->uri->getPassword());
 		}
 		if (!$bind) {
-			throw new Error('bind was not successfull: ' . $this->connection->error());
+			throw new Error(sprintf(
+				'bind was not successfull to %1$s: %2$s',
+				$this->uri->toString(),
+				$this->connection->error()
+			));
 		}
 		return $this;
 	}

--- a/src/Wrapper/Ldap.php
+++ b/src/Wrapper/Ldap.php
@@ -54,7 +54,10 @@ final class Ldap implements LdapInterface
 
 	public function error()
 	{
-		return ldap_error($this->connection);
+		$error = ldap_error($this->connection);
+		ldap_get_option($this->connection, LDAP_OPT_DIAGNOSTIC_MESSAGE, $err);
+
+		return $error . "\n" . $err;
 	}
 
 	public function errno()

--- a/tests/LdapTest.php
+++ b/tests/LdapTest.php
@@ -37,6 +37,7 @@ use Exception;
 use Generator;
 use Org_Heigl\AuthLdap\LdapUri;
 use Org_Heigl\AuthLdap\Wrapper\LdapFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Org_Heigl\AuthLdap\Manager\Ldap;
 
@@ -48,6 +49,7 @@ class LdapTest extends TestCase
 	 * @param array $expected
 	 * @param array $given
 	 */
+	#[DataProvider('dpInstantiateLdapClass')]
 	public function testInstantiateLdapClass($ldapUri, $debug, $startTls)
 	{
 		$ldap = new Ldap(new LdapFactory(), LdapUri::fromString($ldapUri), $debug, $startTls);
@@ -58,6 +60,7 @@ class LdapTest extends TestCase
 	 * @dataProvider dpExceptionsWhenInstantiatingLdapClass
 	 * @param string $expected
 	 */
+	#[DataProvider('dpExceptionsWhenInstantiatingLdapClass')]
 	public function testExceptionsWhenInstantiatingLdapClass(string $expected)
 	{
 		self::expectException(Exception::class);

--- a/tests/LdapUriTest.php
+++ b/tests/LdapUriTest.php
@@ -6,6 +6,7 @@ use Generator;
 use Org_Heigl\AuthLdap\Exception\InvalidLdapUri;
 use Org_Heigl\AuthLdap\LdapUri;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 use function getenv;
@@ -37,6 +38,7 @@ class LdapUriTest extends TestCase
 	/**
 	 * @dataProvider toStringProvider
 	 */
+	#[DataProvider('toStringProvider')]
 	public function testToString(string $uri, string $result, $user, $password, $baseDn, array $env = []): void
 	{
 		foreach ($env as $key => $value) {
@@ -50,6 +52,7 @@ class LdapUriTest extends TestCase
 	}
 
 	/** @dataProvider fromStringProvider */
+	#[DataProvider('fromStringProvider')]
 	public function testFromString(string $uri, bool $failure = false): void
 	{
 		if ($failure) {
@@ -76,6 +79,7 @@ class LdapUriTest extends TestCase
 	/**
 	 * @dataProvider anonymousProvider
 	 */
+	#[DataProvider('anonymousProvider')]
 	public function testUriIsAnonymous(string $uri): void
 	{
 		$uri = LdapUri::fromString($uri);

--- a/tests/Manager/LDAPBaseTest.php
+++ b/tests/Manager/LDAPBaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- * Copyright (c) 2016-2016} Andreas Heigl<andreas@heigl.org>
+ * Copyright (c) Andreas Heigl<andreas@heigl.org>
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
@@ -19,7 +19,7 @@
  * THE SOFTWARE.
  *
  * @author    Andreas Heigl<andreas@heigl.org>
- * @copyright 2016-2016 Andreas Heigl
+ * @copyright Andreas Heigl
  * @license   http://www.opensource.org/licenses/mit-license.php MIT-License
  * @version   0.0
  * @since     07.06.2016
@@ -32,10 +32,11 @@ use Org_Heigl\AuthLdap\Exception\Error;
 use Org_Heigl\AuthLdap\LdapList;
 use Org_Heigl\AuthLdap\LdapUri;
 use Org_Heigl\AuthLdap\Manager\Ldap;
-use Org_Heigl\AuthLdap\Wrapper\Ldap as LdapWrapper;
 use Org_Heigl\AuthLdap\Wrapper\LdapFactory;
 use Org_Heigl\AuthLdap\Wrapper\LdapInterface;
 use PHPUnit\Framework\Assert;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\TestDox;
 use PHPUnit\Framework\TestCase;
 
 class LDAPBaseTest extends TestCase
@@ -58,6 +59,8 @@ class LDAPBaseTest extends TestCase
      * @dataProvider bindingWithPasswordProvider
      * @testdox Binding user $user with password $password using a filter $filter works
      */
+	#[TestDox('Binding user $user with password $password using a filter $filter works')]
+	#[DataProvider('bindingWithPasswordProvider')]
     public function testThatBindingWithPasswordWorks($user, $password, $filter, $uri)
     {
 		$uri = LdapUri::fromString($uri);
@@ -111,9 +114,10 @@ class LDAPBaseTest extends TestCase
     }
 
     /**
-     * @param $uri
+     * @param string $uri
      * @dataProvider initialBindingToLdapServerWorksProvider
      */
+	#[DataProvider('initialBindingToLdapServerWorksProvider')]
     public function testThatInitialBindingWorks($uri)
     {
 	    $this->wrapper
@@ -125,9 +129,10 @@ class LDAPBaseTest extends TestCase
     }
 
     /**
-     * @param $uri
+     * @param string $uri
      * @dataProvider initialBindingToLdapServerWorksProvider
      */
+	#[DataProvider('initialBindingToLdapServerWorksProvider')]
     public function testThatInitialBindingToMultipleLdapsWorks($uri)
     {
 		$this->wrapper->expects($this->once())
@@ -151,6 +156,7 @@ class LDAPBaseTest extends TestCase
     /**
      * @dataProvider provideUnescapedData
      */
+	#[DataProvider('provideUnescapedData')]
     public function testThatPassedDataIsEscaped($unescaped, $escaped): void
     {
         $ldap = new LDAP($this->factory, LdapUri::fromString(


### PR DESCRIPTION
They now also include diagnostic messages when those are available. Also the bind-error log now also includes the URI that it failed to bind to for better debugging.

This should fix #270