### PR TITLE
Fix problem with double search

### DIFF
--- a/authLdap.php
+++ b/authLdap.php
@@ -306,10 +306,10 @@ function authLdap_login($user, $username, $password, $already_md5 = false)
 			DoNotOverwriteNonLdapUsers::fromString(authLdap_get_option('DoNotOverwriteNonLdapUsers')),
 			CachePassword::fromString(authLdap_get_option('CachePW')),
 		);
-		$loggedInUser = $mapper($loggedInUser);
+		$WPUser = $mapper($loggedInUser);
 	}
 
-	if ($loggedInUser instanceof WP_User) {
+	if ($WPUser instanceof WP_User) {
 		$logger->log(var_export(authLdap_get_option('Groups'), true));
 		$authorizer = new Authorize(
 			$ldapServerList,
@@ -325,10 +325,11 @@ function authLdap_login($user, $username, $password, $already_md5 = false)
 			Groups::fromArray(authLdap_get_option('Groups', [])),
 			UidAttribute::fromString(authLdap_get_option('UidAttr')),
 		);
-		$loggedInUser = $authorizer($loggedInUser);
+
+		$WPUser = $authorizer($WPUser, $loggedInUser);
 	}
 
-	return $loggedInUser;
+	return $WPUser;
 }
 
 /**

--- a/features/log in with role-assignement in LDAP based on DN .feature
+++ b/features/log in with role-assignement in LDAP based on DN .feature
@@ -1,0 +1,16 @@
+Feature: Log in with role-assignement in LDAP based on DN
+	Scenario: A user logs in that has an LDAP-role based on the users DN
+		Given a default configuration
+		And configuration value "Filter" is set to "mail=%1$s"
+		And configuration value "GroupEnable" is set to "true"
+		And configuration value "DefaultRole" is set to "subscriber"
+		And configuration value "GroupAttr" is set to "cn"
+		And configuration value "GroupFilter" is set to "uniquemember=%dn%"
+		And configuration value "Groups" is set to "subscriber=ldapgroup1" and "editor=ldapgroup3"
+		And an LDAP user "ldapuser" with name "LDAP User", password "P@ssw0rd" and email "ldapuser@example.com" exists
+		And an LDAP group "ldapgroup1" exists
+		And LDAP user "ldapuser" is member of LDAP group "ldapgroup1"
+		And a WordPress user "ldapuser" does not exist
+		When user "ldapuser@example.com" logs in with password "P@ssw0rd"
+		Then the login suceeds
+		And the WordPress user "ldapuser" is member of role "subscriber"

--- a/src/Authorize.php
+++ b/src/Authorize.php
@@ -13,6 +13,7 @@ use Org_Heigl\AuthLdap\Value\GroupFilter;
 use Org_Heigl\AuthLdap\Value\GroupOverUser;
 use Org_Heigl\AuthLdap\Value\Groups;
 use Org_Heigl\AuthLdap\Value\GroupSeparator;
+use Org_Heigl\AuthLdap\Value\LoggedInUser;
 use Org_Heigl\AuthLdap\Value\UidAttribute;
 use Org_Heigl\AuthLdap\Value\UserFilter;
 use WP_Roles;
@@ -75,7 +76,7 @@ final class Authorize
 	/**
 	 * @return false|WP_User
 	 */
-	public function __invoke(WP_User $user)
+	public function __invoke(WP_User $user, LoggedInUser $loggedInUser)
 	{
 		try {
 			$roles = [];
@@ -100,11 +101,12 @@ final class Authorize
 				// FIXME: add correct parameters
 				$userInfoLdap = $this->backend->search(sprintf(
 					(string) $this->userFilter,
-					$user->user_login,
+					$loggedInUser->getUsername(),
 				), [(string) $this->uidAttribute, 'dn']);
-				if ($userInfoLdap === []) {
+				if ($userInfoLdap['count'] === 0) {
 					$this->logger->log('Retrieving userinfo again failed');
 				}
+
 				$mappedRoles = $this->groupmap(
 					$userInfoLdap[0][(string) $this->uidAttribute][0],
 					$userInfoLdap[0]['dn']


### PR DESCRIPTION
Due to the change in authentication and authorization we need to search the use4r a second time during the authorization phase. Should the user have been identified with a different property than the one used for the WordPress username, that would fail as we passed in only the WP_User that didn't have the original parameter anymore.

I could instead also have created a filter myself based on the WP_User objects username and the username attribute, now that i think about it. This seemed more straight forward...

Fixes #274 